### PR TITLE
Added null check for wmap prompt deallocation (closes #1191)

### DIFF
--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -4220,7 +4220,9 @@ public class WMap extends EngineState {
         break;
 
       case END_MOVEMENT_8:
-        this.wmapLocationPromptPopup.deallocate();
+        if(this.wmapLocationPromptPopup != null) {
+          this.wmapLocationPromptPopup.deallocate();
+        }
         this.mapTransitionState_800c68a4 = MapTransitionState.INIT_0;
         this.mapState_800c6798.disableInput_d0 = false;
         this.mapState_800c6798.shortForceMovementMode_d4 = ForcedMovementMode.NONE_0;


### PR DESCRIPTION
Fixes crash reported in discord when running into big dot after leaving hellena the first time. Seems like it enters a branch I didn't realize it would when hitting a terminal dot with no location attached.