### PR TITLE
Input Toggle for GameSpeedMultiplier

### DIFF
--- a/src/main/java/legend/core/Config.java
+++ b/src/main/java/legend/core/Config.java
@@ -75,6 +75,7 @@ public final class Config {
   }
 
   private static int gameSpeedMultiplier = 1;
+  private static int loadedGameSpeedMultiplier = 1;
 
   public static boolean lowMemoryUnpacker() {
     return readBool("low_memory_unpacker", false);
@@ -135,6 +136,14 @@ public final class Config {
   public static void setGameSpeedMultiplier(final int multiplier) {
     gameSpeedMultiplier = multiplier;
     properties.setProperty("game_speed_multiplier", String.valueOf(multiplier));
+  }
+
+  public static int getLoadedGameSpeedMultiplier() {
+    return loadedGameSpeedMultiplier;
+  }
+
+  public static void setLoadedGameSpeedMultiplier(final int multiplier) {
+    loadedGameSpeedMultiplier = multiplier;
   }
 
   public static Vector3f getBattleRgb() {
@@ -301,6 +310,7 @@ public final class Config {
   public static void load() throws IOException {
     properties.load(Files.newInputStream(path, StandardOpenOption.READ));
     gameSpeedMultiplier = readInt("game_speed_multiplier", 1, 1, 16);
+    loadedGameSpeedMultiplier = gameSpeedMultiplier;
   }
 
   public static void save() throws IOException {

--- a/src/main/java/legend/game/Scus94491BpeSegment.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment.java
@@ -163,6 +163,7 @@ import static legend.game.Scus94491BpeSegment_800c.sequenceData_800c4ac8;
 import static legend.game.combat.environment.StageData.stageData_80109a98;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_DELETE;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_F12;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_Q;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_W;
 import static org.lwjgl.glfw.GLFW.GLFW_MOD_CONTROL;
 
@@ -373,6 +374,14 @@ public final class Scus94491BpeSegment {
 
       if((mods & GLFW_MOD_CONTROL) != 0 && key == GLFW_KEY_W && currentEngineState_8004dd04 instanceof final Battle battle) {
         battle.endBattle();
+      }
+
+      if((mods & GLFW_MOD_CONTROL) != 0 && key == GLFW_KEY_Q) {
+        if(Config.getGameSpeedMultiplier() == 1) {
+          Config.setGameSpeedMultiplier(Config.getLoadedGameSpeedMultiplier());
+        } else {
+          Config.setGameSpeedMultiplier(1);
+        }
       }
     });
 

--- a/src/main/java/legend/game/debugger/DebuggerController.java
+++ b/src/main/java/legend/game/debugger/DebuggerController.java
@@ -367,6 +367,7 @@ public class DebuggerController {
   @FXML
   private void setGameSpeedMultiplier(final ActionEvent event) {
     Config.setGameSpeedMultiplier(this.gameSpeedMultiplier.getValue());
+    Config.setLoadedGameSpeedMultiplier(this.gameSpeedMultiplier.getValue());
   }
 
   @FXML


### PR DESCRIPTION
## Motivation
Needing to turn the game speed multiplier back to 1 (off) and then back to some higher game speed multipler. And then doing this a thousand times when testing.

## Scope
I made it so that the extra Config parameter is sourced from config.conf (on load) or Debugger (on set). The +/- shortcuts were intentionally ignored to give a new degree of freedom. Aka, use +/- to customize your session but use the toggle to revert to your preferred config state.

## Hot key
Control + Q.

Not sure what system keys are reserved for. Control+Q is easily accessible (one-handed shortcuts btw) and not in use elsewhere.

## Future
There's a lot more that can be done with game speed multipliers. At the moment, it is all tied to the gameSpeedMulitplier static variable in Config. This value should probably be managed in a class that can then pull from Config and manage the state of the gameSpeedMultiplier option. Ex: Customizations for the multipler specific to submaps, combat, hold toggles, holdandrelease toggles, multiple hotkeys/rebinds for different multiplier stages, changing the base of the onandoff toggle...etc.

Don't think my PR merits this above overhead.