### PR TITLE
Combat Hot Keys

### DIFF
--- a/src/main/java/legend/game/combat/ui/BattleHud.java
+++ b/src/main/java/legend/game/combat/ui/BattleHud.java
@@ -2365,31 +2365,31 @@ public class BattleHud {
           }
         }
 
+        // Dragoon
         if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_UP))) {
           selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[4]) ? iconFlags_800c7194[4] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
+        // Special
         if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_DOWN))) {
           selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[7]) ? iconFlags_800c7194[7] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
-        if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_RIGHT))) {
-          selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[6]) ? iconFlags_800c7194[2] : iconFlags_800c7194[6];
-          playSound(0, 40, 0, 0, (short)0, (short)0);
-        }
-
+        // Escape
         if(Input.pressedThisFrame((InputAction.BUTTON_SHOULDER_LEFT_1))) {
           selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[3]) ? iconFlags_800c7194[3] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
+        // Guard
         if(Input.pressedThisFrame((InputAction.BUTTON_SHOULDER_RIGHT_1))) {
           selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[1]) ? iconFlags_800c7194[1] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
+        // Item Menu | Dragoon Spells
         if(Input.pressedThisFrame((InputAction.BUTTON_WEST))) {
           selectedAction = this.battleMenu_800c6c34.retrieveIconEnabled(iconFlags_800c7194[2], iconFlags_800c7194[6]);
           this.checkInvalidSelectedAction(selectedAction);

--- a/src/main/java/legend/game/combat/ui/BattleHud.java
+++ b/src/main/java/legend/game/combat/ui/BattleHud.java
@@ -2366,32 +2366,32 @@ public class BattleHud {
         }
 
         if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_UP))) {
-          selectedAction = this.battleMenu_800c6c34.isIconEnabled(2) ? 2 : 0;
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[4]) ? iconFlags_800c7194[4] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
         if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_DOWN))) {
-          selectedAction = this.battleMenu_800c6c34.isIconEnabled(7) ? 7 : 0;
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[7]) ? iconFlags_800c7194[7] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
         if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_RIGHT))) {
-          selectedAction = this.battleMenu_800c6c34.isIconEnabled(3) ? 5 : 3;
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[6]) ? iconFlags_800c7194[2] : iconFlags_800c7194[6];
           playSound(0, 40, 0, 0, (short)0, (short)0);
         }
 
         if(Input.pressedThisFrame((InputAction.BUTTON_SHOULDER_LEFT_1))) {
-          selectedAction = this.battleMenu_800c6c34.isIconEnabled(6) ? 6 : 0;
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[3]) ? iconFlags_800c7194[3] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
         if(Input.pressedThisFrame((InputAction.BUTTON_SHOULDER_RIGHT_1))) {
-          selectedAction = this.battleMenu_800c6c34.isIconEnabled(1) ? 1 : 0;
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(iconFlags_800c7194[1]) ? iconFlags_800c7194[1] : 0;
           this.checkInvalidSelectedAction(selectedAction);
         }
 
         if(Input.pressedThisFrame((InputAction.BUTTON_WEST))) {
-          selectedAction = this.battleMenu_800c6c34.retrieveIconEnabled(3, 5);
+          selectedAction = this.battleMenu_800c6c34.retrieveIconEnabled(iconFlags_800c7194[2], iconFlags_800c7194[6]);
           this.checkInvalidSelectedAction(selectedAction);
         }
 
@@ -2511,7 +2511,9 @@ public class BattleHud {
   }
 
   private void checkInvalidSelectedAction(final int selectedAction) {
-    if(selectedAction == 0) playSound(0, 40, 0, 0, (short)0, (short)0);
+    if(selectedAction == 0) {
+      playSound(0, 40, 0, 0, (short)0, (short)0);
+    }
   }
 
   @Method(0x800f6b04L)

--- a/src/main/java/legend/game/combat/ui/BattleHud.java
+++ b/src/main/java/legend/game/combat/ui/BattleHud.java
@@ -2365,6 +2365,36 @@ public class BattleHud {
           }
         }
 
+        if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_UP))) {
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(2) ? 2 : 0;
+          this.checkInvalidSelectedAction(selectedAction);
+        }
+
+        if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_DOWN))) {
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(7) ? 7 : 0;
+          this.checkInvalidSelectedAction(selectedAction);
+        }
+
+        if(Input.pressedThisFrame((InputAction.JOYSTICK_RIGHT_BUTTON_RIGHT))) {
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(3) ? 5 : 3;
+          playSound(0, 40, 0, 0, (short)0, (short)0);
+        }
+
+        if(Input.pressedThisFrame((InputAction.BUTTON_SHOULDER_LEFT_1))) {
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(6) ? 6 : 0;
+          this.checkInvalidSelectedAction(selectedAction);
+        }
+
+        if(Input.pressedThisFrame((InputAction.BUTTON_SHOULDER_RIGHT_1))) {
+          selectedAction = this.battleMenu_800c6c34.isIconEnabled(1) ? 1 : 0;
+          this.checkInvalidSelectedAction(selectedAction);
+        }
+
+        if(Input.pressedThisFrame((InputAction.BUTTON_WEST))) {
+          selectedAction = this.battleMenu_800c6c34.retrieveIconEnabled(3, 5);
+          this.checkInvalidSelectedAction(selectedAction);
+        }
+
         // Input for pressing X on menu bar
         //LAB_800f671c
         if((press_800bee94 & 0x20) != 0) {
@@ -2478,6 +2508,10 @@ public class BattleHud {
 
     //LAB_800f6aec
     return selectedAction;
+  }
+
+  private void checkInvalidSelectedAction(final int selectedAction) {
+    if(selectedAction == 0) playSound(0, 40, 0, 0, (short)0, (short)0);
   }
 
   @Method(0x800f6b04L)

--- a/src/main/java/legend/game/combat/ui/BattleMenuStruct58.java
+++ b/src/main/java/legend/game/combat/ui/BattleMenuStruct58.java
@@ -14,6 +14,8 @@ import legend.game.types.Translucency;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+
 import static legend.game.combat.ui.BattleHud.battleMenuIconHeights_800fb6bc;
 
 public class BattleMenuStruct58 {
@@ -340,5 +342,17 @@ public class BattleMenuStruct58 {
         this.targetArrows[i] = null;
       }
     }
+  }
+
+  public boolean isIconEnabled(int value) {
+    return Arrays.stream(this.iconFlags_10, 0, this.iconFlags_10.length)
+      .anyMatch(i -> i == value);
+  }
+
+  public int retrieveIconEnabled(int... values) {
+    return Arrays.stream(this.iconFlags_10, 0, this.iconFlags_10.length)
+      .filter(i -> Arrays.stream(values).anyMatch(value -> value == i))
+      .findFirst()
+      .orElse(0);
   }
 }

--- a/src/main/java/legend/game/combat/ui/BattleMenuStruct58.java
+++ b/src/main/java/legend/game/combat/ui/BattleMenuStruct58.java
@@ -344,12 +344,12 @@ public class BattleMenuStruct58 {
     }
   }
 
-  public boolean isIconEnabled(int value) {
+  public boolean isIconEnabled(final int value) {
     return Arrays.stream(this.iconFlags_10, 0, this.iconFlags_10.length)
       .anyMatch(i -> i == value);
   }
 
-  public int retrieveIconEnabled(int... values) {
+  public int retrieveIconEnabled(final int... values) {
     return Arrays.stream(this.iconFlags_10, 0, this.iconFlags_10.length)
       .filter(i -> Arrays.stream(values).anyMatch(value -> value == i))
       .findFirst()


### PR DESCRIPTION
### Motivation
- Playing at high game speed multipliers makes navigating the Battle menu difficult
- Supports accessibility
  - Makes one-handed playing easier
  - Permits controller + keyboard usages for accessibility (rebinds)
- The game inputs are live but their inputs are unmapped to any actions
  - Since the its using the integrated InputAction system, we can scope these to only combat contexts
  - Will be seamless with any future hotkey/input rebind functionality later

### Implementation
- Sounds are played on invalid selection w/ a validation check on the hotkey
  - Also a utility method within BattleHud that could replace a few dozen playSound lines (refactoring some logic however)
- battleMenu_800c6c34
  - Added 2 utility methods to retrieve icon status (todo: remove all the duplicated original utils checking for these icon behaviours)
-  iconFlags_800c7194 (BattleHud)
  - Uses this for indices in a non-human readable format to not have extra random ints in BattleHud
  - iconFlags_800c7194 = {4, 1, 5, 6, 2, 9, 3, 7} for reference, enum where btw
- You can not take any action otherwise not enabled for the battle context (seamless integration by big brain Ink)

### Gameplay Changes
- Added a 'Do nothing' bind (skip turn)
  - Useful for regular testing where you just do not want to take any turn action
  - Also useful while in Dragoon form to take no action
    - WTB 'Run' icon being enabled in Dragoon form RFC

### Mappings
- Attack -> None, since the default is already X on turn start (unnecessary)
- Guard -> 1 -> 1 -> BUTTON_SHOULDER_RIGHT -> Intentional: to be on the same left hand side as the movement joystick
- Item/DMagic -> 3, 5 -> 2, 6 -> BUTTON_WEST -> Just made sense, if BUTTON_NORTH is Addition menu + most modern games would put a 'open menu' button on the ordinal buttons alongside Select, Cancel
- Skip Turn -> Use a disabled icon and set the action to that int (nice hack ✔)
  - If Items can be used in Dragoon form this poses a problem...until then!
- Dragoon -> 2 -> 4 -> Joystick Right UP -> To POWER UP, accessible on right hand where you take action
- Special -> 7 -> 7 -> Joystick Right DOWN -> Needs to be opposite to Dragoon to avoid accidents on the Joystick

Of course, better suggestions for mappings are appreciated. I think these largely make the most sense for usability/flow.

### Challenges
- battleMenu_800c6c34.iconFlags_10 changes its values based on battle context
 
### Future
- I noticed 8 is missing as an icon flag
- De-Dragoon icon possibilities...seems natural
- Would be the only icon I personally think would merit as a core game play extension to the default iconFlags and to take advantage of
- Unless 8 is used somewhere and I'm ignorant
