### PR TITLE
Controls Menu | Disable Mouse Input

### DIFF
--- a/src/main/java/legend/core/RenderEngine.java
+++ b/src/main/java/legend/core/RenderEngine.java
@@ -32,6 +32,7 @@ import legend.game.combat.Battle;
 import legend.game.input.InputAction;
 import legend.game.modding.coremod.CoreMod;
 import legend.game.types.Translucency;
+import legend.game.input.Input;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joml.Matrix4f;
@@ -1131,9 +1132,13 @@ public class RenderEngine {
       LOGGER.info("Allow movement: %b", this.allowMovement);
 
       if(this.allowMovement) {
-        this.window.hideCursor();
+        this.window.disableCursor();
       } else {
-        this.window.showCursor();
+        if(CONFIG.getConfig(CoreMod.DISABLE_MOUSE_INPUT_CONFIG.get()) && !Input.getController().getGuid().isEmpty()) {
+          this.window.hideCursor();
+        } else {
+          this.window.showCursor();
+        }
       }
     }
   }

--- a/src/main/java/legend/core/opengl/GuiManager.java
+++ b/src/main/java/legend/core/opengl/GuiManager.java
@@ -383,7 +383,7 @@ public class GuiManager {
 
     final NkMouse mouse = this.ctx.input().mouse();
     if(mouse.grab()) {
-      this.window.hideCursor();
+      this.window.disableCursor();
     } else if(mouse.grabbed()) {
       final float prevX = mouse.prev().x();
       final float prevY = mouse.prev().y();

--- a/src/main/java/legend/core/opengl/Window.java
+++ b/src/main/java/legend/core/opengl/Window.java
@@ -32,6 +32,7 @@ import static org.lwjgl.glfw.GLFW.GLFW_CONTEXT_VERSION_MAJOR;
 import static org.lwjgl.glfw.GLFW.GLFW_CONTEXT_VERSION_MINOR;
 import static org.lwjgl.glfw.GLFW.GLFW_CURSOR;
 import static org.lwjgl.glfw.GLFW.GLFW_CURSOR_DISABLED;
+import static org.lwjgl.glfw.GLFW.GLFW_CURSOR_HIDDEN;
 import static org.lwjgl.glfw.GLFW.GLFW_CURSOR_NORMAL;
 import static org.lwjgl.glfw.GLFW.GLFW_DECORATED;
 import static org.lwjgl.glfw.GLFW.GLFW_DISCONNECTED;
@@ -50,6 +51,7 @@ import static org.lwjgl.glfw.GLFW.glfwCreateWindow;
 import static org.lwjgl.glfw.GLFW.glfwDestroyWindow;
 import static org.lwjgl.glfw.GLFW.glfwGetClipboardString;
 import static org.lwjgl.glfw.GLFW.glfwGetFramebufferSize;
+import static org.lwjgl.glfw.GLFW.glfwGetInputMode;
 import static org.lwjgl.glfw.GLFW.glfwGetKey;
 import static org.lwjgl.glfw.GLFW.glfwGetPrimaryMonitor;
 import static org.lwjgl.glfw.GLFW.glfwGetVideoMode;
@@ -254,12 +256,20 @@ public class Window {
     glfwSetWindowShouldClose(this.window, true);
   }
 
-  public void hideCursor() {
+  public void disableCursor() {
     glfwSetInputMode(this.window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
   }
 
   public void showCursor() {
     glfwSetInputMode(this.window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+  }
+
+  public void hideCursor() {
+    glfwSetInputMode(this.window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+  }
+
+  public boolean isCursorVisible() {
+    return glfwGetInputMode(this.window, GLFW_CURSOR) != GLFW_CURSOR_HIDDEN;
   }
 
   public void setCursorPos(final double x, final double y) {

--- a/src/main/java/legend/core/opengl/Window.java
+++ b/src/main/java/legend/core/opengl/Window.java
@@ -268,10 +268,6 @@ public class Window {
     glfwSetInputMode(this.window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
   }
 
-  public boolean isCursorVisible() {
-    return glfwGetInputMode(this.window, GLFW_CURSOR) != GLFW_CURSOR_HIDDEN;
-  }
-
   public void setCursorPos(final double x, final double y) {
     glfwSetCursorPos(this.window, x, y);
   }

--- a/src/main/java/legend/game/input/Input.java
+++ b/src/main/java/legend/game/input/Input.java
@@ -216,6 +216,10 @@ public final class Input {
     }
   }
 
+  public static Controller getController() {
+    return activeController;
+  }
+
   public static void rumble(final float bigIntensity, final float smallIntensity, final int ms) {
     activeController.rumble(bigIntensity, smallIntensity, ms);
   }
@@ -246,6 +250,10 @@ public final class Input {
     if(controllerFromConfig.isBlank() || controllerFromConfig.equals(controller.getGuid())) {
       useController(controller);
       CONFIG.setConfig(CoreMod.CONTROLLER_CONFIG.get(), controller.getGuid());
+
+      if(CONFIG.getConfig(CoreMod.DISABLE_MOUSE_INPUT_CONFIG.get())) {
+        RENDERER.window().hideCursor();
+      }
     }
   }
 
@@ -254,6 +262,7 @@ public final class Input {
 
     if(activeController == controller) {
       useController(null);
+      RENDERER.window().showCursor();
     }
   }
 

--- a/src/main/java/legend/game/inventory/screens/ControlHost.java
+++ b/src/main/java/legend/game/inventory/screens/ControlHost.java
@@ -1,6 +1,8 @@
 package legend.game.inventory.screens;
 
+import legend.game.input.Input;
 import legend.game.input.InputAction;
+import legend.game.modding.coremod.CoreMod;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -8,6 +10,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import static legend.core.GameEngine.CONFIG;
 
 public abstract class ControlHost implements Iterable<Control> {
   private final List<Control> controls = new ArrayList<>();
@@ -109,6 +113,10 @@ public abstract class ControlHost implements Iterable<Control> {
   }
 
   protected InputPropagation mouseMove(final int x, final int y) {
+    if(CONFIG.getConfig(CoreMod.DISABLE_MOUSE_INPUT_CONFIG.get()) && !Input.getController().getGuid().isEmpty()) {
+      return InputPropagation.HANDLED;
+    }
+
     this.mouseX = x;
     this.mouseY = y;
 
@@ -122,6 +130,10 @@ public abstract class ControlHost implements Iterable<Control> {
   }
 
   protected InputPropagation mouseClick(final int x, final int y, final int button, final int mods) {
+    if(CONFIG.getConfig(CoreMod.DISABLE_MOUSE_INPUT_CONFIG.get()) && !Input.getController().getGuid().isEmpty()) {
+      return InputPropagation.HANDLED;
+    }
+
     final Control control = this.findControlAt(x, y);
 
     if(control != null && !control.isDisabled()) {

--- a/src/main/java/legend/game/inventory/screens/MenuScreen.java
+++ b/src/main/java/legend/game/inventory/screens/MenuScreen.java
@@ -1,11 +1,15 @@
 package legend.game.inventory.screens;
 
 import legend.game.SItem;
+import legend.game.input.Input;
 import legend.game.input.InputAction;
+import legend.game.modding.coremod.CoreMod;
 
 import javax.annotation.Nullable;
 import java.util.LinkedList;
 import java.util.Queue;
+
+import static legend.core.GameEngine.CONFIG;
 
 public abstract class MenuScreen extends ControlHost {
   private final Queue<Runnable> deferredActions = new LinkedList<>();
@@ -81,6 +85,10 @@ public abstract class MenuScreen extends ControlHost {
 
   @Override
   protected InputPropagation mouseClick(final int x, final int y, final int button, final int mods) {
+    if(CONFIG.getConfig(CoreMod.DISABLE_MOUSE_INPUT_CONFIG.get()) && !Input.getController().getGuid().isEmpty()) {
+      return InputPropagation.HANDLED;
+    }
+
     this.updateHover(x, y);
     this.updateFocus(x, y);
 

--- a/src/main/java/legend/game/modding/coremod/CoreMod.java
+++ b/src/main/java/legend/game/modding/coremod/CoreMod.java
@@ -21,6 +21,7 @@ import legend.game.modding.coremod.config.IndicatorModeConfigEntry;
 import legend.game.modding.coremod.config.InventorySizeConfigEntry;
 import legend.game.modding.coremod.config.MashModeConfigEntry;
 import legend.game.modding.coremod.config.MusicVolumeConfigEntry;
+import legend.game.modding.coremod.config.DisableMouseInputConfigEntry;
 import legend.game.modding.coremod.config.ResolutionConfig;
 import legend.game.modding.coremod.config.SecondaryCharacterXpMultiplierConfigEntry;
 import legend.game.modding.coremod.config.SubmapWidescreenModeConfig;
@@ -76,6 +77,7 @@ public class CoreMod {
   public static final RegistryDelegate<ControllerConfigEntry> CONTROLLER_CONFIG = CONFIG_REGISTRAR.register("controller", ControllerConfigEntry::new);
   public static final RegistryDelegate<ControllerDeadzoneConfigEntry> CONTROLLER_DEADZONE_CONFIG = CONFIG_REGISTRAR.register("controller_deadzone", ControllerDeadzoneConfigEntry::new);
   public static final RegistryDelegate<BoolConfigEntry> RECEIVE_INPUT_ON_INACTIVE_WINDOW_CONFIG = CONFIG_REGISTRAR.register("receive_input_on_inactive_window", () -> new BoolConfigEntry(false, ConfigStorageLocation.GLOBAL, ConfigCategory.CONTROLS));
+  public static final RegistryDelegate<BoolConfigEntry> DISABLE_MOUSE_INPUT_CONFIG = CONFIG_REGISTRAR.register("disable_mouse_input", DisableMouseInputConfigEntry::new);
   public static final RegistryDelegate<BoolConfigEntry> RUMBLE_CONFIG = CONFIG_REGISTRAR.register("rumble", () -> new BoolConfigEntry(true, ConfigStorageLocation.GLOBAL, ConfigCategory.CONTROLS));
   public static final RegistryDelegate<BoolConfigEntry> ALLOW_WIDESCREEN_CONFIG = CONFIG_REGISTRAR.register("allow_widescreen", AllowWidescreenConfigEntry::new);
   public static final RegistryDelegate<SubmapWidescreenModeConfig> SUBMAP_WIDESCREEN_MODE_CONFIG = CONFIG_REGISTRAR.register("submap_widescreen_mode", SubmapWidescreenModeConfig::new);

--- a/src/main/java/legend/game/modding/coremod/config/DisableMouseInputConfigEntry.java
+++ b/src/main/java/legend/game/modding/coremod/config/DisableMouseInputConfigEntry.java
@@ -10,7 +10,7 @@ import static legend.core.GameEngine.RENDERER;
 
 public class DisableMouseInputConfigEntry extends BoolConfigEntry {
   public DisableMouseInputConfigEntry() {
-    super(true, ConfigStorageLocation.GLOBAL, ConfigCategory.CONTROLS);
+    super(false, ConfigStorageLocation.GLOBAL, ConfigCategory.CONTROLS);
   }
 
   @Override

--- a/src/main/java/legend/game/modding/coremod/config/DisableMouseInputConfigEntry.java
+++ b/src/main/java/legend/game/modding/coremod/config/DisableMouseInputConfigEntry.java
@@ -1,0 +1,24 @@
+package legend.game.modding.coremod.config;
+
+import legend.game.input.Input;
+import legend.game.saves.BoolConfigEntry;
+import legend.game.saves.ConfigCategory;
+import legend.game.saves.ConfigCollection;
+import legend.game.saves.ConfigStorageLocation;
+
+import static legend.core.GameEngine.RENDERER;
+
+public class DisableMouseInputConfigEntry extends BoolConfigEntry {
+  public DisableMouseInputConfigEntry() {
+    super(true, ConfigStorageLocation.GLOBAL, ConfigCategory.CONTROLS);
+  }
+
+  @Override
+  public void onChange(final ConfigCollection configCollection, final Boolean oldValue, final Boolean newValue) {
+    if(newValue && !Input.getController().getGuid().isEmpty()) {
+      RENDERER.window().hideCursor();
+    } else {
+      RENDERER.window().showCursor();
+    }
+  }
+}

--- a/src/main/java/legend/game/title/Ttle.java
+++ b/src/main/java/legend/game/title/Ttle.java
@@ -23,6 +23,8 @@ import legend.game.fmv.Fmv;
 import legend.game.input.Input;
 import legend.game.input.InputAction;
 import legend.game.inventory.WhichMenu;
+import legend.game.inventory.screens.InputPropagation;
+import legend.game.modding.coremod.CoreMod;
 import legend.game.inventory.screens.CampaignSelectionScreen;
 import legend.game.inventory.screens.FullScreenInputScreen;
 import legend.game.inventory.screens.MenuScreen;
@@ -614,6 +616,10 @@ public class Ttle extends EngineState {
 
   private void addInputHandlers() {
     onMouseMove = RENDERER.events().onMouseMove((window, x, y) -> {
+      if(CONFIG.getConfig(CoreMod.DISABLE_MOUSE_INPUT_CONFIG.get()) && !Input.getController().getGuid().isEmpty()) {
+        return;
+      }
+
       final float aspect = 4.0f / 3.0f;
 
       float w = window.getWidth();
@@ -655,6 +661,10 @@ public class Ttle extends EngineState {
     });
 
     onMouseRelease = RENDERER.events().onMouseRelease((window, x, y, button, mods) -> {
+      if(CONFIG.getConfig(CoreMod.DISABLE_MOUSE_INPUT_CONFIG.get()) && !Input.getController().getGuid().isEmpty()) {
+        return;
+      }
+
       if(button != GLFW.GLFW_MOUSE_BUTTON_LEFT) {
         return;
       }


### PR DESCRIPTION
Play Severed Chains with mouse input disabled. 

### Description
- Hides mouse cursor
- Disables mouse clicks
- Controls do not react to mouse movement, scrolling, or mouse clicks
- Only works if a controller is connected and in use
  - Cursor becomes functional if controller is disconnected

### Motivation
- 💠 Cinematic immersion 💠 
- Controller-only mode (TV setups)
- Avoids niche issues with touchscreen inputs on laptops / TVs / monitors
- In fullscreen border / maximized view the cursor can be hidden
  - Great for single monitor users
  - Helpful for streaming software compatibility
- Click-through overlay programs will work properly
  - Accessibility programs using click-through overlays
- Various mouse based input emulations will work more easily
  - ex: emulating a steering wheel on your mouse as your daily driver
- In the future, modders / us can add specific functionality to controllers that would otherwise break with mouse input
  - ex: controller-designed-only menus / UI
  - ex: rotational-fixed movement UI / game play / cameras (skill issue)

### MenuScreen, ControlHost

Since mouseClick in MenuScreen has a special case for handling mouse clicks w/ regards to hover and focus, the check for mouse input had to be added here, on top of it being added to the super call (since the super method can be used by other screens not going through MenuScreen).

### Window Object
This does not disable window-level mouse inputs.

The mouse is also still tracked by the Window object for its position and is listening for mouse inputs (but they go nowhere currently).

### MenuStack
Atm, could elevate this to MenuStack instead of ControlHost for the current functionality present for menus in-game. But since we may have OtherStack and AdditionalStack that use ControlHost, ControlHost seemed the best to stick the checks.

ex: battle menus, non-menu UIs, modders using ControlHost but not a MenuStack implementation

### getController in Input.java
Is this fine to return the activeController object? It is static and is already edited by many other classes?

### Debugger
Mouse is never hidden in the debugger.

### Renamed GLFW Inputs

![image](https://github.com/user-attachments/assets/81ad7799-d820-4289-ba56-b5d790219216)

Very interesting naming scheme, though I think this is standard for games.

Since the free cam one was using disabled but the method was called hideCursor, but I wanted the hidden functionality...renamed the methods + they match the documentation now.