### PR TITLE
Battle | HUD | Potential Revisions

### DIFF
--- a/src/main/java/legend/game/combat/ui/AdditionListMenu.java
+++ b/src/main/java/legend/game/combat/ui/AdditionListMenu.java
@@ -159,7 +159,7 @@ public class AdditionListMenu extends ListMenu {
         }
 
         this.description.render(Config.changeBattleRgb() ? Config.getBattleRgb() : Config.defaultUiColour);
-        renderCentredText("Hits: " + additionData.attacks_01 + ", damage: " + damage + ", SP: " + sp, 160, 157, TextColour.WHITE, 0);
+        renderCentredText("Hits: " + additionData.attacks_01 + ", Damage: " + damage + ", SP: " + sp, 160, 157, TextColour.WHITE, 0);
       }
     }
   }

--- a/src/main/java/legend/game/combat/ui/ItemListMenu.java
+++ b/src/main/java/legend/game/combat/ui/ItemListMenu.java
@@ -39,8 +39,8 @@ public class ItemListMenu extends ListMenu {
   @Override
   protected void drawListEntry(final int index, final int x, final int y, final int trim) {
     renderText(I18n.translate(this.combatItems_800c6988.get(index).item), x, y, TextColour.WHITE, trim);
-    renderText("\u011d", x + 143, y, TextColour.WHITE, trim);
-    renderRightText(String.valueOf(this.combatItems_800c6988.get(index).count), x + 168, y, TextColour.WHITE, trim);
+    renderText("\u011d", x + 141, y, TextColour.WHITE, trim);
+    renderRightText(String.valueOf(this.combatItems_800c6988.get(index).count), x + 166, y, TextColour.WHITE, trim);
   }
 
   @Override

--- a/src/main/java/legend/game/combat/ui/ListMenu.java
+++ b/src/main/java/legend/game/combat/ui/ListMenu.java
@@ -437,7 +437,7 @@ public abstract class ListMenu {
           //LAB_800f5e24
           if(this.listScroll_1e > 0) {
             this.transforms.identity();
-            this.transforms.transfer.set(this.x_04 + 82, this.y_06 + t0 - 100, 124.0f);
+            this.transforms.transfer.set(this.x_04 + 81, this.y_06 + t0 - 97, 124.0f);
             RENDERER.queueOrthoModel(this.menuObj, this.transforms, QueuedModelStandard.class)
               .vertices(this.upObjOffset, 4);
           }
@@ -445,7 +445,7 @@ public abstract class ListMenu {
           //LAB_800f5e7c
           if(this.listScroll_1e + 6 < this.getListCount() - 1) {
             this.transforms.identity();
-            this.transforms.transfer.set(this.x_04 + 82, this.y_06 + s1 - 7, 124.0f);
+            this.transforms.transfer.set(this.x_04 + 81, this.y_06 + s1 - 10, 124.0f);
             RENDERER.queueOrthoModel(this.menuObj, this.transforms, QueuedModelStandard.class)
               .vertices(this.downObjOffset, 4);
           }

--- a/src/main/java/legend/game/combat/ui/SpellListMenu.java
+++ b/src/main/java/legend/game/combat/ui/SpellListMenu.java
@@ -62,10 +62,7 @@ public class SpellListMenu extends ListMenu {
     renderText(spellStats_800fa0b8[spellId].name, x, y, textColour, trim);
     renderRightText(String.valueOf(this.player_08.spell_94.mp_06), x + 152, y, TextColour.WHITE, trim);
 
-    this.transforms.scaling(0.75f);
-    this.transforms.transfer.set(x + 152, y, 124.0f);
-    RENDERER.queueOrthoModel(this.menuObj, this.transforms, QueuedModelStandard.class)
-      .vertices(this.mpObjOffset, 4);
+    renderText("MP", x + 155, y, TextColour.WHITE, 0);
 
     this.player_08.setActiveSpell(currentSpellId);
   }


### PR DESCRIPTION
### Changes
- Capitalized D in 'damage' in `Addition List Menu`
- Replaced the super pixelated MP icon with just "MP" text in the `Spell List Menu`
  - Plans to make this (and other texts) scale smaller to be more aesthetic (have text scaling in another PR, but no aliasing)
- `ListMenu` Scroll Arrows
  - Moved their x and y coords to be more aesthetic with regards to the UiBox borders
  - Moved `Item List Menu` 'X' and quantity positions slightly to compensate 

### Visuals
Damage
![image](https://github.com/user-attachments/assets/a1d3a26d-724c-463a-b7b4-d2ff44f64801)
MP proper text
![image](https://github.com/user-attachments/assets/d8ac0a06-867f-4d4f-b021-ac16ac0c95ec)
Arrows not scrolling
![image](https://github.com/user-attachments/assets/4cc45234-5c3b-41bc-aa8e-762234505ab6)
Arrows scrolling
![image](https://github.com/user-attachments/assets/d179d2ea-9917-4112-956b-fb8b985b5059)
