### PR TITLE
git: Ignore jdk and isos folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,6 @@
 
 
 
-/.idea/gradle.xml
-/.idea/misc.xml
-
-
-
 # Compiled class file
 *.class
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ gradle-app.setting
 
 # Mac
 .DS_STORE
+
+# JDK files
+/jdk*

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,5 @@
 # Default ignored files
+/gradle.xml
+/misc.xml
 /shelf/
 /workspace.xml

--- a/isos/.gitignore
+++ b/isos/.gitignore
@@ -1,1 +1,2 @@
-*.iso
+*
+!.gitignore


### PR DESCRIPTION
I don't like to cherry-pick files while creating a commit. Ideally you want to ignore any file that is the result from compilation or setup.