### PR TITLE
Added a fleq condition to calculateStep for camera

### DIFF
--- a/src/main/java/legend/game/combat/environment/BattleCamera.java
+++ b/src/main/java/legend/game/combat/environment/BattleCamera.java
@@ -2503,7 +2503,13 @@ public class BattleCamera {
 
     //LAB_800dcf48
     if(stepType == 1) {
-      return (val2 - val1) / divisor;
+      if(!MathHelper.flEq(0, val1 - val2, 0.0002f) && val1 > val2) {
+        //LAB_800dcf6c
+        return (val2 - val1 + MathHelper.TWO_PI) / divisor;
+      }
+    //LAB_800dcf84
+    } else if(val1 <= val2) {
+      return (val2 - val1 - MathHelper.TWO_PI) / divisor;
     }
 
     //LAB_800dcf58


### PR DESCRIPTION
Due to float math rounding discrepancies, sometimes the start and dest values for camera movement take the wrong branch by being unequal when they should be equal. Restoring the code removed in 0b756337 and adding a negative fleq condition to the `val1 > val2` comparison catches these scenarios with an epsilon small enough that it shouldn't catch real differences.

Tested Fruegel slam, Burn Out, and Living Statue Power Up, all worked as expected.

Closes #1638, re closes #1285, #1526 