### PR TITLE
Fixed Man in Hood's rotation being wrong

### DIFF
--- a/src/main/java/legend/game/submap/SubmapObject210.java
+++ b/src/main/java/legend/game/submap/SubmapObject210.java
@@ -51,9 +51,9 @@ public class SubmapObject210 {
   public int interpRotationTicksTotalX;
   public int interpRotationTicksTotalY;
   public int interpRotationTicksTotalZ;
-  public int lastRotationTickX = Integer.MIN_VALUE;
-  public int lastRotationTickY = Integer.MIN_VALUE;
-  public int lastRotationTickZ = Integer.MIN_VALUE;
+  public long lastRotationTickX = Integer.MIN_VALUE;
+  public long lastRotationTickY = Integer.MIN_VALUE;
+  public long lastRotationTickZ = Integer.MIN_VALUE;
 
   /** Only one sobj may have this value set at a time */
   public boolean cameraAttached_178;


### PR DESCRIPTION
Integer.MIN_VALUE is 0x8000_0000, which is read as negative 2 billion whatever dec. When tick - Integer.MIN_VALUE is computed, it does not underflow, it just resolves to 0x8000_0001, which is still a negative number, meaning the conditions in scriptSetModelRotate evaluate false instead of true. Expanding the field to a long means the equation evaluates to a positive number instead, as intended. Boat rotation and Giganto arrows also still orient correctly.

Fixes #1641 