### PR TITLE
Removed modifier check from keyRelease

### DIFF
--- a/src/main/java/legend/game/input/Input.java
+++ b/src/main/java/legend/game/input/Input.java
@@ -187,10 +187,6 @@ public final class Input {
   }
 
   private static void keyRelease(final Window window, final int key, final int scancode, final int mods) {
-    if(mods != 0) {
-      return;
-    }
-
     for(final InputBinding inputBinding : activeController.bindings) {
       if(inputBinding.getInputType() == InputType.KEYBOARD && CONFIG.getConfig(CoreMod.KEYBIND_CONFIGS.get(inputBinding.getInputAction()).get()).contains(key)) {
         inputBinding.setReleasedForKeyboardInput();


### PR DESCRIPTION
Holding a modifier key (shift, ctrl, etc.) caused keyRelease to return before processing the release, meaning the last input would continue to behave as if held. Pressing the key again without the modifier would stop this because it would finally run the release code for the locked key. Removing the check allows the key to release normally.