### PR TITLE
Converted acceleration scaler from fip8 to float

### DIFF
--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -882,14 +882,14 @@ public final class SEffe {
     if(mode == 0) {
       effect.scaleOrUseEffectAcceleration_6c = true;
       effect.effectAcceleration_70.set(script.params_20[2].get() / (float)0x100, script.params_20[3].get() / (float)0x100, script.params_20[4].get() / (float)0x100);
-      effect.scaleParticleAcceleration_80 = script.params_20[5].get();
+      effect.scaleParticleAcceleration_80 = script.params_20[5].get() / (float)0x100;
       //LAB_801023d0
     } else if(mode == 1) {
       effect.scaleOrUseEffectAcceleration_6c = false;
       //LAB_801023e0
     } else if(mode == 2) {
       //LAB_801023e8
-      effect.scaleParticleAcceleration_80 = script.params_20[5].get();
+      effect.scaleParticleAcceleration_80 = script.params_20[5].get() / (float)0x100;
     }
 
     //LAB_801023ec

--- a/src/main/java/legend/game/combat/particles/ParticleEffectData98.java
+++ b/src/main/java/legend/game/combat/particles/ParticleEffectData98.java
@@ -46,7 +46,7 @@ public abstract class ParticleEffectData98 implements Effect<EffectManagerParams
   public boolean scaleOrUseEffectAcceleration_6c;
 
   public final Vector3f effectAcceleration_70 = new Vector3f();
-  public int scaleParticleAcceleration_80;
+  public float scaleParticleAcceleration_80;
 //  public BiConsumer<EffectManagerData6c<EffectManagerParams.ParticleType>, ParticleEffectInstance94> particleInstancePrerenderCallback_84;
 //  public BiConsumer<EffectManagerData6c<EffectManagerParams.ParticleType>, ParticleEffectInstance94> particleInstanceTickCallback_88;
 //  public Consumer<ParticleEffectInstance94> initializerCallback_8c;


### PR DESCRIPTION
Caused stupid-big acceleration values in particles that used the acceleration scaler.

Closes #1812 and certainly some others that will need to be looked for.