### PR TITLE
Get retail tick count for submap scripts

### DIFF
--- a/src/main/java/legend/game/scripting/GameVarParam.java
+++ b/src/main/java/legend/game/scripting/GameVarParam.java
@@ -39,7 +39,7 @@ public class GameVarParam extends Param {
     return switch(this.index) {
       case 0 -> Scus94491BpeSegment_8004.engineState_8004dd20.ordinal();
       case 1 -> Scus94491BpeSegment_800b.pregameLoadingStage_800bb10c;
-      case 2 -> Scus94491BpeSegment_800b.tickCount_800bb0fc;
+      case 2 -> Scus94491BpeSegment_800b.tickCount_800bb0fc / currentEngineState_8004dd04.tickMultiplier();
       case 3 -> currentEngineState_8004dd04.getScriptInput(SCRIPTS.joypadInput);
       case 4 -> currentEngineState_8004dd04.getScriptInput(SCRIPTS.joypadPress);
       case 5 -> Scus94491BpeSegment_800b.gameState_800babc8.gold_94;


### PR DESCRIPTION
Some scripts use the current tick count as a trigger for certain events, usually checking to see if it is an odd number or if it's divisible by a certain amount.

In the case of roaming Hellena Prison wardens in the towers, it checks to see if the current tick count is divisible by 100 or 200 (depending on the tower). The 2x tick multiplier used for 60fps means that they will spawn twice as fast. It also means that if an odd number of ticks are skipped, they'll stop spawning altogether.

closes #1850 