### PR TITLE
Fixed Selebus' zambo hand positioning

### DIFF
--- a/patches/scripts.csv
+++ b/patches/scripts.csv
@@ -69,6 +69,7 @@ diff,SECT/DRGN0.BIN/5268/1,scripts/DRGN0/5268/1.diff,"Polter helm command block,
 diff,SECT/DRGN0.BIN/5274/1,scripts/DRGN0/5274/1.diff,"DD Spirit Leg Swipe, fix character count crash"
 diff,SECT/DRGN0.BIN/5288/1,scripts/DRGN0/5288/1.diff,"Regole Spirit Tsunami, fix character count crash"
 diff,SECT/DRGN0.BIN/5312/1,scripts/DRGN0/5312/1.diff,"Selebus singing, fix character count crash"
+diff,SECT/DRGN0.BIN/5316/1,scripts/DRGN0/5316/1.diff,"Selebus zambo hands' manager not getting secondary bobj index"
 diff,SECT/DRGN0.BIN/5326/1,scripts/DRGN0/5326/1.diff,"Kubila Froggy, fix character count crash"
 diff,SECT/DRGN0.BIN/5334/1,scripts/DRGN0/5334/1.diff,"Zackwell Skeleton, fix character count crash"
 diff,SECT/DRGN0.BIN/5344/1,scripts/DRGN0/5344/1.diff,"Zackwell - Lavitz (weird move), fix character count crash"

--- a/patches/scripts/DRGN0/5316/1.diff
+++ b/patches/scripts/DRGN0/5316/1.diff
@@ -1,0 +1,18 @@
+--- original
++++ modified
+@@ -2008,6 +2008,7 @@
+ deallocate_other stor[18]
+ return
+ LABEL_98:
++gosub inl[:LABEL_17]
+ gosub inl[:LABEL_126]
+ gosub inl[:LABEL_81]
+ gosub inl[:LABEL_79]
+@@ -2018,7 +2019,6 @@
+ mov 0x25d17, stor[stor[stor[0], 18], 8]
+ call 547, stor[18], 0xffffffff, 0x0, 0xa00, 0x0
+ call 545, stor[18], stor[28], 0x0, 0x0, 0x0
+-gosub inl[:LABEL_17]
+ gosub inl[:LABEL_111]
+ gosub inl[:LABEL_64]
+ call 545, stor[18], stor[28], 0x0, 0x0, 0x0


### PR DESCRIPTION
One of the oldest remaining bugs, vanquished at last.

Turns out that fixing the crash with #329 didn't break anything, but did reveal that this deff script was already broken. Instead of having the storage for the secondary bobj index that is used to attach parent script translation to the effect initialized properly, in retail it was only working because the manager script happened to be reallocated to the same memory as the previous iteration of itself and accidentally inherited the correct values. Properly setting all storage values to -1 as was done previously is the correct fix for the crash in #174, the deff for the attack needed to be altered to correctly update these storage values before attempting to calculate relative positions.

Fixes #1808 