### PR TITLE
Fix mod events using final on moddable properties

### DIFF
--- a/src/main/java/legend/game/modding/events/battle/BattleMusicEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/BattleMusicEvent.java
@@ -4,8 +4,8 @@ import legend.game.combat.bent.BattleEvent;
 import legend.game.combat.environment.StageData2c;
 
 public class BattleMusicEvent extends BattleEvent {
-  public final int victoryType;
-  public final int musicIndex;
+  public int victoryType;
+  public int musicIndex;
   public final StageData2c stageData;
 
   public BattleMusicEvent(final int victoryType, final int musicIndex, final StageData2c stageData) {

--- a/src/main/java/legend/game/modding/events/submap/SubmapEncounterAccumulatorEvent.java
+++ b/src/main/java/legend/game/modding/events/submap/SubmapEncounterAccumulatorEvent.java
@@ -2,7 +2,7 @@ package legend.game.modding.events.submap;
 
 public class SubmapEncounterAccumulatorEvent extends SubmapEvent {
   public final float encounterAccumulator;
-  public final float encounterAccumulatedStep;
+  public float encounterAccumulatedStep;
   public final float encounterMultiplier;
   public final int vsyncMode;
   public final int encounterAccumulatorLimit;

--- a/src/main/java/legend/game/modding/events/submap/SubmapEncounterRateEvent.java
+++ b/src/main/java/legend/game/modding/events/submap/SubmapEncounterRateEvent.java
@@ -1,7 +1,7 @@
 package legend.game.modding.events.submap;
 
 public class SubmapEncounterRateEvent extends SubmapEvent {
-  public final int encounterRate;
+  public int encounterRate;
   public final int submapId;
 
   public SubmapEncounterRateEvent(final int encounterRate, final int submapId) {

--- a/src/main/java/legend/game/modding/events/submap/SubmapGenerateEncounterEvent.java
+++ b/src/main/java/legend/game/modding/events/submap/SubmapGenerateEncounterEvent.java
@@ -1,8 +1,8 @@
 package legend.game.modding.events.submap;
 
 public class SubmapGenerateEncounterEvent extends SubmapEvent{
-  public final int encounterId;
-  public final int battleStageId;
+  public int encounterId;
+  public int battleStageId;
   public final int submapId;
   public final int sceneId;
   public final int[] scene;


### PR DESCRIPTION
Fix oversight in what mod event properties are moddable and which ones are a) not used after the event, and b) should be for reference only (which is communicated to the modder by the property being 'final' on their end).

If the other properties gain function instead of just context then it is a non-breaking change to un-final them.