### PR TITLE
Improve Encounters

### DIFF
--- a/src/main/java/legend/game/debugger/DebuggerController.java
+++ b/src/main/java/legend/game/debugger/DebuggerController.java
@@ -307,13 +307,7 @@ public class DebuggerController {
   @FXML
   private void startEncounter(final ActionEvent event) {
     if(currentEngineState_8004dd04 instanceof final SMap smap) {
-      smap.submap.generateEncounter();
-      encounterId_800bb0f8 = this.encounterId.getValue();
-
-      if(Config.combatStage()) {
-        battleStage_800bb0f4 = Config.getCombatStage();
-      }
-
+      smap.submap.prepareEncounter(this.encounterId.getValue());
       smap.mapTransition(-1, 0);
     } else if(currentEngineState_8004dd04 instanceof final WMap wmap) {
       encounterId_800bb0f8 = this.encounterId.getValue();

--- a/src/main/java/legend/game/submap/RetailSubmap.java
+++ b/src/main/java/legend/game/submap/RetailSubmap.java
@@ -409,18 +409,15 @@ public class RetailSubmap extends Submap {
   }
 
   @Override
-  public void prepareEncounter(final int targetEncounterId) {
+  public void prepareEncounter(final Integer targetEncounterId) {
     final var sceneId = encounterData_800f64c4[this.cut].scene_00;
     final var scene = sceneEncounterIds_800f74c4[sceneId];
-    final var encounterId = targetEncounterId == 0 ? scene[this.randomEncounterIndex()] : targetEncounterId;
-    final var battleStageId = encounterData_800f64c4[this.cut].stage_03;
+    final var encounterId = targetEncounterId == null ? scene[this.randomEncounterIndex()] : targetEncounterId;
+    final var battleStageId = encounterData_800f64c4[this.cut].stage_03 == 0 && battleStage_800bb0f4 > -1 ? battleStage_800bb0f4 : encounterData_800f64c4[this.cut].stage_03;
 
     final var generateEncounterEvent = EVENTS.postEvent(new SubmapGenerateEncounterEvent(encounterId, battleStageId, this.cut, sceneId, scene));
     encounterId_800bb0f8 = generateEncounterEvent.encounterId;
-
-    if(generateEncounterEvent.battleStageId != 0) {
-      battleStage_800bb0f4 = generateEncounterEvent.battleStageId;
-    }
+    battleStage_800bb0f4 = generateEncounterEvent.battleStageId;
 
     if(Config.combatStage()) {
       battleStage_800bb0f4 = Config.getCombatStage();

--- a/src/main/java/legend/game/submap/RetailSubmap.java
+++ b/src/main/java/legend/game/submap/RetailSubmap.java
@@ -2,6 +2,7 @@ package legend.game.submap;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import legend.core.Config;
 import legend.core.QueuedModel;
 import legend.core.QueuedModelStandard;
 import legend.core.QueuedModelTmd;
@@ -408,15 +409,22 @@ public class RetailSubmap extends Submap {
   }
 
   @Override
-  public void generateEncounter() {
+  public void prepareEncounter(final int targetEncounterId) {
     final var sceneId = encounterData_800f64c4[this.cut].scene_00;
     final var scene = sceneEncounterIds_800f74c4[sceneId];
-    final var encounterId = scene[this.randomEncounterIndex()];
+    final var encounterId = targetEncounterId == 0 ? scene[this.randomEncounterIndex()] : targetEncounterId;
     final var battleStageId = encounterData_800f64c4[this.cut].stage_03;
 
     final var generateEncounterEvent = EVENTS.postEvent(new SubmapGenerateEncounterEvent(encounterId, battleStageId, this.cut, sceneId, scene));
     encounterId_800bb0f8 = generateEncounterEvent.encounterId;
-    battleStage_800bb0f4 = generateEncounterEvent.battleStageId;
+
+    if(generateEncounterEvent.battleStageId != 0) {
+      battleStage_800bb0f4 = generateEncounterEvent.battleStageId;
+    }
+
+    if(Config.combatStage()) {
+      battleStage_800bb0f4 = Config.getCombatStage();
+    }
   }
 
   @Override

--- a/src/main/java/legend/game/submap/RetailSubmap.java
+++ b/src/main/java/legend/game/submap/RetailSubmap.java
@@ -409,10 +409,9 @@ public class RetailSubmap extends Submap {
   }
 
   @Override
-  public void prepareEncounter(final Integer targetEncounterId) {
+  public void prepareEncounter(final int encounterId) {
     final var sceneId = encounterData_800f64c4[this.cut].scene_00;
     final var scene = sceneEncounterIds_800f74c4[sceneId];
-    final var encounterId = targetEncounterId == null ? scene[this.randomEncounterIndex()] : targetEncounterId;
     final var battleStageId = encounterData_800f64c4[this.cut].stage_03 == 0 && battleStage_800bb0f4 > -1 ? battleStage_800bb0f4 : encounterData_800f64c4[this.cut].stage_03;
 
     final var generateEncounterEvent = EVENTS.postEvent(new SubmapGenerateEncounterEvent(encounterId, battleStageId, this.cut, sceneId, scene));
@@ -422,6 +421,14 @@ public class RetailSubmap extends Submap {
     if(Config.combatStage()) {
       battleStage_800bb0f4 = Config.getCombatStage();
     }
+  }
+
+  @Override
+  public void prepareEncounter() {
+    final var sceneId = encounterData_800f64c4[this.cut].scene_00;
+    final var scene = sceneEncounterIds_800f74c4[sceneId];
+    final var encounterId = scene[this.randomEncounterIndex()];
+    this.prepareEncounter(encounterId);
   }
 
   @Override

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -3623,6 +3623,14 @@ public class SMap extends EngineState {
       return;
     }
 
+    if(this.isScriptLoaded(0)) {
+      final SubmapObject210 sobj = this.sobjs_800c6880[0].innerStruct_00;
+      screenOffsetBeforeBattle_800bed50.set(this.screenOffset_800cb568);
+      this.submap.storeStateBeforeBattle();
+      playerPositionBeforeBattle_800bed30.set(sobj.model_00.coord2_14.coord);
+      shouldRestoreCameraPosition_80052c40 = true;
+    }
+
     this.smapLoadingStage_800cb430 = SubmapState.TRANSITION_TO_COMBAT_19;
   }
 
@@ -3972,12 +3980,6 @@ public class SMap extends EngineState {
 
     if(script.params_20[0].get() == -1) {
       this.submap.prepareEncounter(scene);
-
-      final SubmapObject210 sobj = this.sobjs_800c6880[0].innerStruct_00;
-      screenOffsetBeforeBattle_800bed50.set(this.screenOffset_800cb568);
-      this.submap.storeStateBeforeBattle();
-      playerPositionBeforeBattle_800bed30.set(sobj.model_00.coord2_14.coord);
-      shouldRestoreCameraPosition_80052c40 = true;
     }
 
     this.mapTransition(script.params_20[0].get(), scene);

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -769,7 +769,7 @@ public class SMap extends EngineState {
       case CHECK_TRANSITIONS_1_2:
         if((this.submapFlags_800f7e54 & 0x1) == 0) {
           if(this.canEncounter()) {
-            this.submap.prepareEncounter(0);
+            this.submap.prepareEncounter(null);
             this.mapTransition(-1, 0);
           }
         }

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -156,6 +156,7 @@ import static legend.game.Scus94491BpeSegment_800b.whichMenu_800bdc38;
 import static legend.game.Scus94491BpeSegment_800c.lightColourMatrix_800c3508;
 import static legend.game.Scus94491BpeSegment_800c.lightDirectionMatrix_800c34e8;
 import static legend.game.Scus94491BpeSegment_800c.worldToScreenMatrix_800c3548;
+import static legend.game.combat.environment.StageData.stageData_80109a98;
 import static org.lwjgl.opengl.GL11C.GL_LESS;
 import static org.lwjgl.opengl.GL11C.GL_LINES;
 import static org.lwjgl.opengl.GL11C.GL_TRIANGLE_STRIP;
@@ -3629,19 +3630,12 @@ public class SMap extends EngineState {
       return;
     }
 
-    final int encounterId;
-    if(newScene == 0) {
-      encounterId = encounterId_800bb0f8;
-    } else {
-      if(newScene > 0x1ff) {
-        SCRIPTS.pause();
-        return;
-      }
-
-      encounterId = newScene;
+    if(newScene != 0 && newScene >= stageData_80109a98.length) {
+      SCRIPTS.pause();
+      return;
     }
 
-    encounterId_800bb0f8 = encounterId;
+    encounterId_800bb0f8 = newScene == 0 ? encounterId_800bb0f8 : newScene;
 
     if(this.isScriptLoaded(0)) {
       final SubmapObject210 sobj = this.sobjs_800c6880[0].innerStruct_00;

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -1,6 +1,5 @@
 package legend.game.submap;
 
-import legend.core.Config;
 import legend.core.IoHelper;
 import legend.core.MathHelper;
 import legend.core.QueuedModelStandard;
@@ -131,9 +130,7 @@ import static legend.game.Scus94491BpeSegment_8005.textboxMode_80052b88;
 import static legend.game.Scus94491BpeSegment_8005.textboxTextType_80052ba8;
 import static legend.game.Scus94491BpeSegment_8007.vsyncMode_8007a3b8;
 import static legend.game.Scus94491BpeSegment_800b._800bd7b0;
-import static legend.game.Scus94491BpeSegment_800b.battleStage_800bb0f4;
 import static legend.game.Scus94491BpeSegment_800b.drgnBinIndex_800bc058;
-import static legend.game.Scus94491BpeSegment_800b.encounterId_800bb0f8;
 import static legend.game.Scus94491BpeSegment_800b.fullScreenEffect_800bb140;
 import static legend.game.Scus94491BpeSegment_800b.gameState_800babc8;
 import static legend.game.Scus94491BpeSegment_800b.loadedDrgnFiles_800bcf78;
@@ -769,7 +766,7 @@ public class SMap extends EngineState {
       case CHECK_TRANSITIONS_1_2:
         if((this.submapFlags_800f7e54 & 0x1) == 0) {
           if(this.canEncounter()) {
-            this.submap.prepareEncounter(null);
+            this.submap.prepareEncounter();
             this.mapTransition(-1, 0);
           }
         }

--- a/src/main/java/legend/game/submap/Submap.java
+++ b/src/main/java/legend/game/submap/Submap.java
@@ -35,7 +35,8 @@ public abstract class Submap {
   public abstract void calcGoodScreenOffset(final float x, final float y, final Vector2f out);
 
   public abstract int getEncounterRate();
-  public abstract void prepareEncounter(final Integer targetEncounterId);
+  public abstract void prepareEncounter();
+  public abstract void prepareEncounter(final int encounterId);
 
   public boolean hasEncounters() {
     return this.getEncounterRate() != 0;

--- a/src/main/java/legend/game/submap/Submap.java
+++ b/src/main/java/legend/game/submap/Submap.java
@@ -35,7 +35,7 @@ public abstract class Submap {
   public abstract void calcGoodScreenOffset(final float x, final float y, final Vector2f out);
 
   public abstract int getEncounterRate();
-  public abstract void prepareEncounter(final int targetEncounterId);
+  public abstract void prepareEncounter(final Integer targetEncounterId);
 
   public boolean hasEncounters() {
     return this.getEncounterRate() != 0;

--- a/src/main/java/legend/game/submap/Submap.java
+++ b/src/main/java/legend/game/submap/Submap.java
@@ -35,7 +35,7 @@ public abstract class Submap {
   public abstract void calcGoodScreenOffset(final float x, final float y, final Vector2f out);
 
   public abstract int getEncounterRate();
-  public abstract void generateEncounter();
+  public abstract void prepareEncounter(final int targetEncounterId);
 
   public boolean hasEncounters() {
     return this.getEncounterRate() != 0;


### PR DESCRIPTION
### Description
- Debugger BattleStage selector did not work for Contact Encounters
- Debugger BattleStage logic was in multiple places
- Encounter flows were divergent and had a mix of duplicated logic in multiple places

### tl:dr
- Debugger BattleStageId control works for all encounter types with all stages
- Encounter flow logic consolidated, streamlined, and updated
- Removed 0 being false and an int
- Encounter related mod events will now work for all encounter types

---

### 0a24d0f

**Good**
- Unnest if else logic
- Conform the nested else if to the rest of the method's early return convention
- Make ternary the disjointed logic checks for encounterId_800bb0f8
  - Remove unnecessay encounterId blank finalization variable
- 0x1ff -> stageData_80109a98.length as this is what its checking for and what its counterpart does in handleEncounters flow

**Bad**
- Don't like that the previous state of encounterId_800bb0f8 is used as a fallback / error as it adds error surface area
- StageData is relying on global state and submap controller script sync to be correct (non-ideal)
- Still a secondary but unjustifiable reason to keep this flow separate from parts of handleEncounter flow
- Index IDs are non-ideal

### 943e407

**Good**
- battlestage debugger control works for all encounter types
- battlestage debugger check is checked only once now instead of 3 times in mutliple places
- battlestage debugger startEncounter is now 1:1 with scriptMapTransition
  - Compared to these implementations being the same intent but with diverged implementations
  - startEncounter's submap battle checks *should* be movable to somewhere else pending script adjustments with scriptMapTransition
- battlestage mod events now works in one place without any other wonk in multiple places
- Easier future rewrite for whatever Script Translation Layer | BattleMediator | Battle State Machine rewrite occurs

**Bad**
- prepareEncounter
  - Ugly if checks not resolved by proper contesting and flows
    - But this is where they belong
  - Can't actually start encounter id of 0 via debugger
  - Can't mod event battle id of 0
- scriptMapTransition
  - Same as above, ugly if check for combat condition
    - Can't resolve w/o some rewrite in whatever Script Translation Layer | BattleMediator | Battle State Machine rewrite occurs
    - scriptMapTransitionBattle should exist and be used in scripts when we want to do battle map transitions
    - But scriptMapTransition is used for it all from scripts

### 0e7bc01

**Good**
- Recover all prior existing functionality in prepareEncounter that was missed out in the previous commit
- Much cleaner
- Debugger, Mod Events, Contact Encounters, and Walkable Encounters should now all work without issue

**Bad**
- Not sure what precedence to give Config vs Mod Event...I presume debugger should take ultimate priority

Sent from Android