### PR TITLE
Add animation to Lavitz's mother to fix broken hug cutscene

### DIFF
--- a/patches/scripts.csv
+++ b/patches/scripts.csv
@@ -97,6 +97,7 @@ diff,SECT/DRGN0.BIN/5608/1,scripts/DRGN0/5608/1.diff,"Zackwell Cutscene Part 2, 
 diff,SECT/DRGN0.BIN/5610/1,scripts/DRGN0/5610/1.diff,"Zieg Cutscene, force-load Dart"
 diff,SECT/DRGN21.BIN/36/5,scripts/DRGN21/36/5.diff,"Seles Anim Crash, GH#813"
 diff,SECT/DRGN21.BIN/96/3,scripts/DRGN21/96/3.diff,"Hellena Prison, Lavitz running into walls fix, GH#1083"
+diff,SECT/DRGN21.BIN/249/5,scripts/DRGN21/249/5.diff,"Lavitz's home, add animation to fix hug position, GH#1196"
 diff,SECT/DRGN21.BIN/270/1,scripts/DRGN21/270/1.diff,"Indels Castle, fix ladder animations"
 diff,SECT/DRGN21.BIN/276/1,scripts/DRGN21/276/1.diff,"Indels Castle, fix ladder animations"
 diff,SECT/DRGN21.BIN/339/1,scripts/DRGN21/339/1.diff,"Marshland, adjust piggyback cutscene camera, GH#1063"

--- a/patches/scripts/DRGN21/249/5.diff
+++ b/patches/scripts/DRGN21/249/5.diff
@@ -1,0 +1,77 @@
+--- original
++++ modified
+@@ -106,7 +106,74 @@
+ yield
+ call 1, stor[24]
+ jmp_cmp !=, 0x0, stor[24], inl[:LABEL_16]
++call 102, stor[0], inl[:MOM_X], inl[:MOM_Y], inl[:MOM_Z]
++mov 0x41, inl[:TARGET_X]
++mov 0xffffffcd, inl[:TARGET_Y]
++mov 0x5c, inl[:TARGET_Z]
++gosub inl[:ROTATE_0]
++mov 0x41, inl[:TARGET_X]
++mov 0xffffffcd, inl[:TARGET_Y]
++mov 0x5c, inl[:TARGET_Z]
++sub inl[:TARGET_X], inl[:MOM_X]
++sub inl[:TARGET_Y], inl[:MOM_Y]
++sub inl[:TARGET_Z], inl[:MOM_Z]
++mul inl[:MOM_X], inl[:MOM_X]
++mul inl[:MOM_Y], inl[:MOM_Y]
++mul inl[:MOM_Z], inl[:MOM_Z]
++add inl[:MOM_X], inl[:MOM_Y]
++add inl[:MOM_Y], inl[:MOM_Z]
++sqrt inl[:MOM_Z], inl[:MOM_Z]
++jmp_cmp >, 3, inl[:MOM_Z], inl[:CLOSE]
++jmp inl[:NORMAL]
++CLOSE:
++mov 2, inl[:MOM_Z]
++NORMAL:
++div 2, inl[:MOM_Z]
++call 107, inl[:TARGET_X], inl[:TARGET_Y], inl[:TARGET_Z], inl[:MOM_Z]
++call 99, 0
++call 97, 1
++call 105, inl[:TARGET_X], inl[:TARGET_Y], inl[:TARGET_Z]
++wait inl[:MOM_Z]
++mov inl[:TARGET_X], inl[:MOM_X]
++mov inl[:TARGET_Y], inl[:MOM_Y]
++mov inl[:TARGET_Z], inl[:MOM_Z]
++call 102, var[64][0], inl[:TARGET_X], inl[:TARGET_Y], inl[:TARGET_Z]
++gosub inl[:ROTATE_0]
+ return
++ROTATE_0:
++sub inl[:MOM_X], inl[:TARGET_X]
++sub inl[:MOM_Z], inl[:TARGET_Z]
++atan2_12 inl[:TARGET_X], inl[:TARGET_Z], inl[:TARGET_Y]
++call 104, stor[0], inl[:TARGET_Z], inl[:TARGET_X], inl[:TARGET_Z]
++and 0xfff, inl[:TARGET_X]
++sub inl[:TARGET_X], inl[:TARGET_Y]
++add 0x800, inl[:TARGET_Y]
++360_NEG_BOUND:
++jmp_cmp >=, inl[:TARGET_Y], 0xfffff800, inl[:360_POS_BOUND]
++add 0x1000, inl[:TARGET_Y]
++jmp inl[:LABEL_13]
++360_POS_BOUND:
++jmp_cmp <, inl[:TARGET_Y], 0x800, inl[:ROTATE_1]
++sub 0x1000, inl[:TARGET_Y]
++ROTATE_1:
++call 120, stor[0], 0, inl[:TARGET_Y], 0, 10
++call 99, 0
++call 97, 1
++wait 10
++call 97, 0
++return
++MOM_X:
++data 0
++MOM_Y:
++data 0
++MOM_Z:
++data 0
++TARGET_X:
++data 0
++TARGET_Y:
++data 0
++TARGET_Z:
++data 0
+ ENTRYPOINT_0:
+ ENTRYPOINT_2:
+ ENTRYPOINT_3:

--- a/patches/scripts/DRGN21/249/5.diff
+++ b/patches/scripts/DRGN21/249/5.diff
@@ -1,14 +1,16 @@
 --- original
 +++ modified
-@@ -106,7 +106,74 @@
+@@ -106,7 +106,71 @@
  yield
  call 1, stor[24]
  jmp_cmp !=, 0x0, stor[24], inl[:LABEL_16]
+# Rotate to target
 +call 102, stor[0], inl[:MOM_X], inl[:MOM_Y], inl[:MOM_Z]
 +mov 0x41, inl[:TARGET_X]
 +mov 0xffffffcd, inl[:TARGET_Y]
 +mov 0x5c, inl[:TARGET_Z]
 +gosub inl[:ROTATE_0]
+# Calculate movement ticks
 +mov 0x41, inl[:TARGET_X]
 +mov 0xffffffcd, inl[:TARGET_Y]
 +mov 0x5c, inl[:TARGET_Z]
@@ -21,17 +23,16 @@
 +add inl[:MOM_X], inl[:MOM_Y]
 +add inl[:MOM_Y], inl[:MOM_Z]
 +sqrt inl[:MOM_Z], inl[:MOM_Z]
-+jmp_cmp >, 3, inl[:MOM_Z], inl[:CLOSE]
-+jmp inl[:NORMAL]
-+CLOSE:
++jmp_cmp <=, 2, inl[:MOM_Z], inl[:CONTINUE]
 +mov 2, inl[:MOM_Z]
-+NORMAL:
++CONTINUE:
 +div 2, inl[:MOM_Z]
+# Move to target
 +call 107, inl[:TARGET_X], inl[:TARGET_Y], inl[:TARGET_Z], inl[:MOM_Z]
 +call 99, 0
 +call 97, 1
-+call 105, inl[:TARGET_X], inl[:TARGET_Y], inl[:TARGET_Z]
 +wait inl[:MOM_Z]
+# Rotate to face player
 +mov inl[:TARGET_X], inl[:MOM_X]
 +mov inl[:TARGET_Y], inl[:MOM_Y]
 +mov inl[:TARGET_Z], inl[:MOM_Z]


### PR DESCRIPTION
When returning from the rooftop cutscene, Lavitz suggests gathering supplies before leaving Bale. If the player leaves this room and returns, Lavitz's mother will be standing closer to the table, in the position expected for Lavitz's hug cutscene.

This patch adds walking and rotation animations that place her in the correct position after Lavitz suggests ~wasting all of Dart's hard earned gold~ shopping.

[2024-12-26 23-05-54.webm](https://github.com/user-attachments/assets/1bb2d340-4a72-4b41-ad3e-9a022d78114b)

Closes #1196 