### PR TITLE
Maintain clear colour while paused (closes #1908)

### DIFF
--- a/src/main/java/legend/core/RenderEngine.java
+++ b/src/main/java/legend/core/RenderEngine.java
@@ -635,8 +635,7 @@ public class RenderEngine {
 
         // bind backbuffer
         FrameBuffer.unbind();
-        this.setClearColour(0.0f, 0.0f, 0.0f);
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+        glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
         // use screen shader
         screenShader.use();


### PR DESCRIPTION
We don't need to clear the colour because the framebuffer texture is rendered over the whole screen and is entirely opaque. This means we also don't need to overwrite the current clear colour set by the game.