### PR TITLE
Adjust camera for Haschel solo punch cutscene

### DIFF
--- a/patches/scripts.csv
+++ b/patches/scripts.csv
@@ -111,6 +111,7 @@ diff,SECT/DRGN22.BIN/672/7,scripts/DRGN22/672/7.diff,"Twin Castle, fix evening g
 diff,SECT/DRGN22.BIN/672/8,scripts/DRGN22/672/8.diff,"Twin Castle, fix evening guard flashing, GH#1794"
 diff,SECT/DRGN22.BIN/681/1,scripts/DRGN22/681/1.diff,"Adjust text placement for conversation with Kongol in training room, GH#1839"
 diff,SECT/DRGN22.BIN/681/2,scripts/DRGN22/681/2.diff,"Adjust text placement for conversation with Kongol in training room, GH#1839"
+diff,SECT/DRGN22.BIN/795/1,scripts/DRGN22/795/1.diff,"Giganto Home Haschel solo cutscene, set camera within scissor bounds GH#1918"
 diff,SECT/DRGN22.BIN/798/1,scripts/DRGN22/798/1.diff,"Giganto Home outside throne, Haschel leaves, fix unlock party GH#1772"
 diff,SECT/DRGN22.BIN/801/1,scripts/DRGN22/801/1.diff,"Giganto Home throne room, Haschel leaves, fix unlock party GH#1772"
 diff,SECT/DRGN22.BIN/804/1,scripts/DRGN22/804/1.diff,"Giganto Home Gehrich cutscene, Haschel rejoins, fix unlock party GH#1772"

--- a/patches/scripts.csv
+++ b/patches/scripts.csv
@@ -111,7 +111,7 @@ diff,SECT/DRGN22.BIN/672/7,scripts/DRGN22/672/7.diff,"Twin Castle, fix evening g
 diff,SECT/DRGN22.BIN/672/8,scripts/DRGN22/672/8.diff,"Twin Castle, fix evening guard flashing, GH#1794"
 diff,SECT/DRGN22.BIN/681/1,scripts/DRGN22/681/1.diff,"Adjust text placement for conversation with Kongol in training room, GH#1839"
 diff,SECT/DRGN22.BIN/681/2,scripts/DRGN22/681/2.diff,"Adjust text placement for conversation with Kongol in training room, GH#1839"
-diff,SECT/DRGN22.BIN/795/1,scripts/DRGN22/795/1.diff,"Giganto Home Haschel solo cutscene, set camera within scissor bounds GH#1918"
+diff,SECT/DRGN22.BIN/795/1,scripts/DRGN22/795/1.diff,"Giganto Home Haschel solo cutscene, switch camera offset axis GH#1918"
 diff,SECT/DRGN22.BIN/798/1,scripts/DRGN22/798/1.diff,"Giganto Home outside throne, Haschel leaves, fix unlock party GH#1772"
 diff,SECT/DRGN22.BIN/801/1,scripts/DRGN22/801/1.diff,"Giganto Home throne room, Haschel leaves, fix unlock party GH#1772"
 diff,SECT/DRGN22.BIN/804/1,scripts/DRGN22/804/1.diff,"Giganto Home Gehrich cutscene, Haschel rejoins, fix unlock party GH#1772"

--- a/patches/scripts/DRGN22/795/1.diff
+++ b/patches/scripts/DRGN22/795/1.diff
@@ -1,0 +1,28 @@
+Retail camera pans to the left for this cutscene.
+Submap scissoring blocks rendering in this region.
+Submap background is still visible on the right in ultrawide aspect ratios.
+Solution: pan camera down similar to Marshland cutscene.
+--- original
++++ modified
+@@ -1270,9 +1270,9 @@
+ wait stor[24]
+ call 237, 0x8, 0x25, 0x1
+ call 688, stor[0], 0x0
+# Offset is stored to reset. Swapping x and y variables
+-call 257, stor[22], stor[25]
++call 257, stor[25], stor[22]
+ call 264, 0x0, 0x0, 0x0
+-call 258, 0x190, stor[25]
++call 258, stor[25], 0x190
+ mov var[64][1], stor[24]
+ call 101, stor[24], 0x0, 0xffffffb0, 0xfffffdbc
+ call 103, stor[24], 0x0, 0xa00, 0x0
+@@ -1309,7 +1309,7 @@
+ gosub inl[:LABEL_153]
+ call 257, stor[24], stor[25]
+ call 264, 0x2, 0x0, 0x0
+-call 258, stor[22], stor[25]
++call 258, stor[24], stor[22]
+ call 267, 0x8, stor[8], stor[9], stor[10]
+ sub 0x32, stor[8]
+ mov var[64][1], stor[24]

--- a/patches/scripts/DRGN22/795/1.diff
+++ b/patches/scripts/DRGN22/795/1.diff
@@ -1,7 +1,6 @@
-Retail camera pans to the left for this cutscene.
-Submap scissoring blocks rendering in this region.
-Submap background is still visible on the right in ultrawide aspect ratios.
-Solution: pan camera down similar to Marshland cutscene.
+Retail: camera pans to the left using mode 0. Mode 0: offset only applies to 2D elements. 3D geometry does not move.
+Problem: Submap scissoring blocks 3D rendering in this region. 2D background is still visible to the right in very wide aspect ratios.
+Solution: translate offset to y axis instead so geometry renders and background is hidden for all widescreen aspect ratios.
 --- original
 +++ modified
 @@ -1270,9 +1270,9 @@


### PR DESCRIPTION
Moves the camera above the submap rather than to its left. This places it within the scissor's boundaries to render the scene as expected (still cropped to the submap's width).

Closes #1918