### PR TITLE
Fix no MP check on spell list menu

### DIFF
--- a/src/main/java/legend/game/combat/ui/ListMenu.java
+++ b/src/main/java/legend/game/combat/ui/ListMenu.java
@@ -12,6 +12,7 @@ import legend.game.input.Input;
 import legend.game.input.InputAction;
 import legend.game.scripting.RunningScript;
 import legend.game.types.Translucency;
+import legend.lodmod.LodMod;
 
 import static legend.core.GameEngine.RENDERER;
 import static legend.game.Scus94491BpeSegment_8002.playMenuSound;
@@ -274,6 +275,11 @@ public abstract class ListMenu {
           //LAB_800f5078
           this.hud.battleMenu_800c6c34.targetedPlayerSlot_800c6980 = this.player_08.charSlot_276;
           this.onSelection(this.listScroll_1e + this.listIndex_24);
+
+          if(this.player_08.spell_94 != null && this.player_08.stats.getStat(LodMod.MP_STAT.get()).getCurrent() < this.player_08.spell_94.mp_06) {
+            playMenuSound(40);
+            break;
+          }
 
           //LAB_800f5190
           playMenuSound(2);


### PR DESCRIPTION
- spell_94 is set to null at times and can be null in this flow (item list)
- added an mp check along with proper sounding

The initial values of .spell_94 are likely stale data in some way. Initially thought it was monster entity data being left over in the .spell_94 that was not being set to null on battle load / opening menus after the enemy had taken a turn. But Flameshot and Divine Dragon spells have both appeared as initial stale data for non-Dart characters.

Either nodart is making that more complicated or the spell_94 is being set by a stale/garbage/incorrect index on battle load.