### PR TITLE
Modifiers Support and Full-Screen Toggle Keybind Added

### DIFF
--- a/src/main/java/legend/core/Config.java
+++ b/src/main/java/legend/core/Config.java
@@ -1,5 +1,9 @@
 package legend.core;
 
+import legend.game.modding.coremod.CoreMod;
+import legend.game.saves.BoolConfigEntry;
+import legend.game.saves.ConfigStorage;
+import legend.game.saves.ConfigStorageLocation;
 import org.joml.Vector3f;
 
 import java.io.IOException;
@@ -15,6 +19,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+
+import static legend.core.GameEngine.CONFIG;
 
 public final class Config {
   private Config() {
@@ -236,6 +242,13 @@ public final class Config {
 
   public static void setTextBoxColourMode(final int value) {
     properties.setProperty("textbox_colour_mode", String.valueOf(value));
+  }
+
+  public static void switchFullScreen() {
+    final BoolConfigEntry fullScreenConfigEntry = CoreMod.FULLSCREEN_CONFIG.get();
+    final boolean isFullScreen = CONFIG.getConfig(fullScreenConfigEntry);
+    CONFIG.setConfig(fullScreenConfigEntry, !isFullScreen);
+    ConfigStorage.saveConfig(CONFIG, ConfigStorageLocation.GLOBAL, Path.of("config.dcnf"));
   }
 
   public static int getTextBoxRgb(final int textbox) {

--- a/src/main/java/legend/core/RenderEngine.java
+++ b/src/main/java/legend/core/RenderEngine.java
@@ -1104,6 +1104,7 @@ public class RenderEngine {
 
   private void onPressedThisFrame(final Window window, final InputAction inputAction) {
     switch(inputAction) {
+      case InputAction.TOGGLE_FULL_SCREEN -> Config.switchFullScreen();
       case InputAction.SPEED_UP -> Config.setGameSpeedMultiplier(Math.min(Config.getGameSpeedMultiplier() + 1, 16));
       case InputAction.SLOW_DOWN -> Config.setGameSpeedMultiplier(Math.max(Config.getGameSpeedMultiplier() - 1, 1));
       case InputAction.PAUSE -> this.togglePause = !this.togglePause;

--- a/src/main/java/legend/game/input/Input.java
+++ b/src/main/java/legend/game/input/Input.java
@@ -175,20 +175,20 @@ public final class Input {
   }
 
   private static void keyPress(final Window window, final int key, final int scancode, final int mods) {
-    if(mods != 0) {
-      return;
-    }
+    final int keyWithMods = key | mods << 9;
 
     for(final InputBinding inputBinding : activeController.bindings) {
-      if(inputBinding.getInputType() == InputType.KEYBOARD && CONFIG.getConfig(CoreMod.KEYBIND_CONFIGS.get(inputBinding.getInputAction()).get()).contains(key)) {
+      if(inputBinding.getInputType() == InputType.KEYBOARD && CONFIG.getConfig(CoreMod.KEYBIND_CONFIGS.get(inputBinding.getInputAction()).get()).contains(keyWithMods)) {
         inputBinding.setPressedForKeyboardInput();
       }
     }
   }
 
   private static void keyRelease(final Window window, final int key, final int scancode, final int mods) {
+    final int keyWithMods = key | mods << 9;
+
     for(final InputBinding inputBinding : activeController.bindings) {
-      if(inputBinding.getInputType() == InputType.KEYBOARD && CONFIG.getConfig(CoreMod.KEYBIND_CONFIGS.get(inputBinding.getInputAction()).get()).contains(key)) {
+      if(inputBinding.getInputType() == InputType.KEYBOARD && CONFIG.getConfig(CoreMod.KEYBIND_CONFIGS.get(inputBinding.getInputAction()).get()).contains(keyWithMods)) {
         inputBinding.setReleasedForKeyboardInput();
       }
     }
@@ -299,5 +299,6 @@ public final class Input {
     controller.addBinding(new InputBinding(InputAction.FRAME_ADVANCE, controller, InputType.KEYBOARD));
     controller.addBinding(new InputBinding(InputAction.FRAME_ADVANCE_HOLD, controller, InputType.KEYBOARD));
     controller.addBinding(new InputBinding(InputAction.KILL_STUCK_SOUNDS, controller, InputType.KEYBOARD));
+    controller.addBinding(new InputBinding(InputAction.TOGGLE_FULL_SCREEN, controller, InputType.KEYBOARD));
   }
 }

--- a/src/main/java/legend/game/input/InputAction.java
+++ b/src/main/java/legend/game/input/InputAction.java
@@ -47,6 +47,7 @@ public enum InputAction {
   FRAME_ADVANCE(-1),
   FRAME_ADVANCE_HOLD(-1),
   KILL_STUCK_SOUNDS(-1),
+  TOGGLE_FULL_SCREEN(-1),
   ;
 
   public final int hexCode;

--- a/src/main/java/legend/game/inventory/screens/KeybindsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/KeybindsScreen.java
@@ -47,12 +47,16 @@ import static org.lwjgl.glfw.GLFW.GLFW_KEY_SEMICOLON;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_SPACE;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_TAB;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_UP;
+import static org.lwjgl.glfw.GLFW.GLFW_MOD_ALT;
+import static org.lwjgl.glfw.GLFW.GLFW_MOD_CONTROL;
+import static org.lwjgl.glfw.GLFW.GLFW_MOD_SHIFT;
 
 public class KeybindsScreen extends VerticalLayoutScreen {
   private final Runnable unload;
   private final ConfigCollection config;
 
   private final Map<Integer, String> validKeys = new LinkedHashMap<>();
+  private final Map<Integer, String> validMods = new LinkedHashMap<>();
 
   public KeybindsScreen(final ConfigCollection config, final Runnable unload) {
     this.addKey(GLFW_KEY_SPACE, "SPACE");
@@ -77,6 +81,11 @@ public class KeybindsScreen extends VerticalLayoutScreen {
     this.addKey(GLFW_KEY_HOME, "HOME");
     this.addKey(GLFW_KEY_END, "END");
 
+    // Modifiers
+    this.addMod(GLFW_MOD_ALT, "ALT");
+    this.addMod(GLFW_MOD_CONTROL, "CTRL");
+    this.addMod(GLFW_MOD_SHIFT, "SHFT");
+
     for(int i = 0; i < 12; i++) {
       this.addKey(GLFW_KEY_F1 + i, "F" + (i + 1));
     }
@@ -90,7 +99,15 @@ public class KeybindsScreen extends VerticalLayoutScreen {
     this.addControl(new Background());
 
     final Label help = new Label(I18n.translate(CoreMod.MOD_ID + ".keybind.help"));
-    help.setPos(32, 12);
+    final Label supportedMods = new Label(I18n.translate(CoreMod.MOD_ID + ".keybind.mods") + ' ' + String.join(", ", this.validMods.values()));
+
+    supportedMods.setPos(32, 6);
+    supportedMods.setWidth(this.getWidth() - 64);
+    supportedMods.setHorizontalAlign(Label.HorizontalAlign.CENTRE);
+    supportedMods.hide();
+    this.addControl(supportedMods);
+
+    help.setPos(32, 18);
     help.setWidth(this.getWidth() - 64);
     help.setHorizontalAlign(Label.HorizontalAlign.CENTRE);
     help.hide();
@@ -109,6 +126,7 @@ public class KeybindsScreen extends VerticalLayoutScreen {
         textbox.onGotFocus(() -> {
           keycodes.clear();
           textbox.setText("");
+          supportedMods.show();
           help.show();
         });
 
@@ -124,6 +142,7 @@ public class KeybindsScreen extends VerticalLayoutScreen {
           if(dupes.isEmpty()) {
             config.setConfig(CoreMod.KEYBIND_CONFIGS.get(inputAction).get(), new IntOpenHashSet(keycodes));
             help.hide();
+            supportedMods.hide();
           } else {
             this.getStack().pushScreen(new MessageBoxScreen(I18n.translate("lod_core.keybind.duplicate_input"), 2, result -> {
               if(result == MessageBoxResult.YES) {
@@ -135,6 +154,7 @@ public class KeybindsScreen extends VerticalLayoutScreen {
 
               config.setConfig(CoreMod.KEYBIND_CONFIGS.get(inputAction).get(), new IntOpenHashSet(keycodes));
               help.hide();
+              supportedMods.hide();
             }));
           }
         });
@@ -146,7 +166,12 @@ public class KeybindsScreen extends VerticalLayoutScreen {
           }
 
           if(this.validKeys.containsKey(key)) {
-            keycodes.add(key);
+            int currentMod = 0;
+            if(this.validMods.containsKey(mods)) {
+              currentMod = mods << 9;
+            }
+            final int addedKey = key | currentMod;
+            keycodes.add(addedKey);
             textbox.setText(this.keysToString(keycodes));
           }
 
@@ -164,6 +189,10 @@ public class KeybindsScreen extends VerticalLayoutScreen {
     this.validKeys.put(keycode, name);
   }
 
+  private void addMod(final int mod, final String name) {
+    this.validMods.put(mod, name);
+  }
+
   private void addRegularKey(final int keycode) {
     this.addKey(keycode, String.valueOf((char)keycode));
   }
@@ -178,7 +207,13 @@ public class KeybindsScreen extends VerticalLayoutScreen {
     return keycodes.intStream().sorted().mapToObj(this::keyToString).collect(Collectors.joining(", "));
   }
 
-  private String keyToString(final int keycode) {
+  private String keyToString(final int keycode)
+  {
+    final int mod = keycode >> 9;
+    final int key = keycode & 0x1FF;
+    if(mod != 0) {
+      return this.validMods.getOrDefault(mod, "") + '+' + this.validKeys.getOrDefault(key, "");
+    }
     return this.validKeys.getOrDefault(keycode, "");
   }
 

--- a/src/main/java/legend/game/modding/coremod/CoreMod.java
+++ b/src/main/java/legend/game/modding/coremod/CoreMod.java
@@ -65,6 +65,7 @@ import static org.lwjgl.glfw.GLFW.GLFW_KEY_SPACE;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_UP;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_W;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_Z;
+import static org.lwjgl.glfw.GLFW.GLFW_MOD_ALT;
 
 /** Core mod that contains engine-level content. Game can not run without it. */
 @Mod(id = CoreMod.MOD_ID)
@@ -92,6 +93,8 @@ public class CoreMod {
 
   /** Config isn't actually used, but adds a button to the options screen to open the keybinds screen */
   public static final RegistryDelegate<ConfigEntry<Void>> CONTROLLER_KEYBINDS_CONFIG = CONFIG_REGISTRAR.register("controller_keybinds", ControllerKeybindsConfigEntry::new);
+
+  public static final int ALT_ENTER_KEY = (GLFW_MOD_ALT << 9) | GLFW_KEY_ENTER;
 
   public static final Map<InputAction, RegistryDelegate<ControllerKeybindConfigEntry>> KEYBIND_CONFIGS = new EnumMap<>(InputAction.class);
   static {
@@ -123,6 +126,7 @@ public class CoreMod {
     KEYBIND_CONFIGS.put(InputAction.FRAME_ADVANCE, CONFIG_REGISTRAR.register("keybind_frame_advance", () -> new ControllerKeybindConfigEntry(false, GLFW_KEY_F9)));
     KEYBIND_CONFIGS.put(InputAction.FRAME_ADVANCE_HOLD, CONFIG_REGISTRAR.register("keybind_frame_advance_hold", () -> new ControllerKeybindConfigEntry(false, GLFW_KEY_F10)));
     KEYBIND_CONFIGS.put(InputAction.KILL_STUCK_SOUNDS, CONFIG_REGISTRAR.register("keybind_kill_stuck_sounds", () -> new ControllerKeybindConfigEntry(false, GLFW_KEY_F4)));
+    KEYBIND_CONFIGS.put(InputAction.TOGGLE_FULL_SCREEN, CONFIG_REGISTRAR.register("keybind_toggle_full_screen", () -> new ControllerKeybindConfigEntry(false, ALT_ENTER_KEY)));
   }
 
   // Per-campaign config

--- a/src/main/resources/lod_core/lang/en.lang
+++ b/src/main/resources/lod_core/lang/en.lang
@@ -76,6 +76,7 @@ lod_core.config.battle_transition_mode.INSTANT=Instant
 lod_core.config.unlock_party.label=Unlock Party
 
 lod_core.keybind.help=Press DEL when done
+lod_core.keybind.mods=Supported combo keys:
 lod_core.keybind.missing_input=Missing required input
 lod_core.keybind.duplicate_input=Duplicate found, remove?
 lod_core.keybind.BUTTON_NORTH=Triangle
@@ -106,3 +107,4 @@ lod_core.keybind.PAUSE=Pause
 lod_core.keybind.FRAME_ADVANCE=Frame advance
 lod_core.keybind.FRAME_ADVANCE_HOLD=Frame advance (hold)
 lod_core.keybind.KILL_STUCK_SOUNDS=Kill Stuck Sounds
+lod_core.keybind.TOGGLE_FULL_SCREEN=Toggle full screen


### PR DESCRIPTION
Modifiers Support and Full-Screen Toggle Keybind Added

Resolves #1925
Resolves #1926 

Explanation:

- Modifiers are bit-shifted (```<<```) by 9 and logically added (```OR```) to the original keycode, allowing the combination to be saved as a single value in the configuration.
- To extract the original keycode from the combined value, it needs to be logically multiplied (```AND```) with 0x1FF. This is only required in the KeybindScreen to display the key combination.