### PR TITLE
discussion listmenu mp fix

### DIFF
--- a/src/main/java/legend/game/combat/ui/ListMenu.java
+++ b/src/main/java/legend/game/combat/ui/ListMenu.java
@@ -102,6 +102,10 @@ public abstract class ListMenu {
   protected abstract int handleTargeting();
   public abstract void getTargetingInfo(final RunningScript<?> script);
 
+  protected boolean canUse() {
+    return true;
+  };
+
   private void initObjs() {
     if(this.menuObj == null) {
       final QuadBuilder builder = new QuadBuilder("Spell/item menu");
@@ -274,11 +278,9 @@ public abstract class ListMenu {
         if(Input.pressedThisFrame(InputAction.BUTTON_SOUTH)) {
           //LAB_800f5078
           this.hud.battleMenu_800c6c34.targetedPlayerSlot_800c6980 = this.player_08.charSlot_276;
-          this.player_08.spell_94 = null;
-          this.player_08.item_d4 = null;
           this.onSelection(this.listScroll_1e + this.listIndex_24);
 
-          if(this.player_08.spell_94 != null && this.player_08.stats.getStat(LodMod.MP_STAT.get()).getCurrent() < this.player_08.spell_94.mp_06) {
+          if(!this.canUse()) {
             playMenuSound(40);
             break;
           }

--- a/src/main/java/legend/game/combat/ui/ListMenu.java
+++ b/src/main/java/legend/game/combat/ui/ListMenu.java
@@ -274,6 +274,8 @@ public abstract class ListMenu {
         if(Input.pressedThisFrame(InputAction.BUTTON_SOUTH)) {
           //LAB_800f5078
           this.hud.battleMenu_800c6c34.targetedPlayerSlot_800c6980 = this.player_08.charSlot_276;
+          this.player_08.spell_94 = null;
+          this.player_08.item_d4 = null;
           this.onSelection(this.listScroll_1e + this.listIndex_24);
 
           if(this.player_08.spell_94 != null && this.player_08.stats.getStat(LodMod.MP_STAT.get()).getCurrent() < this.player_08.spell_94.mp_06) {

--- a/src/main/java/legend/game/combat/ui/SpellListMenu.java
+++ b/src/main/java/legend/game/combat/ui/SpellListMenu.java
@@ -54,7 +54,7 @@ public class SpellListMenu extends ListMenu {
 
     final TextColour textColour;
     this.setActiveSpell(index);
-    if(this.player_08.stats.getStat(LodMod.MP_STAT.get()).getCurrent() < this.player_08.spell_94.mp_06) {
+    if(!this.canUse()) {
       textColour = TextColour.GREY;
     } else {
       textColour = TextColour.WHITE;
@@ -81,6 +81,13 @@ public class SpellListMenu extends ListMenu {
   @Override
   protected void onSelection(final int index) {
     this.setActiveSpell(index);
+  }
+
+  @Override
+  protected boolean canUse() {
+    final int currentMP = this.player_08.stats.getStat(LodMod.MP_STAT.get()).getCurrent();
+    final int spellMPCost = this.player_08.spell_94.mp_06;
+    return currentMP >= spellMPCost;
   }
 
   private void setActiveSpell(final int index) {


### PR DESCRIPTION
1. The changediff is what clears the stale data and is just there to illustrate the problem
2. Stale data is being populated from enemy turns (aka, garbage data not so much stale data) and is not consistently cleaned up
3. Case 2 needs to be refactored and split each check into a doCase2 for AdditionListMenu, SpellListMenu, and ItemListMenu
4. Likely even the whole tick method and all other cases

- Do you want me to hunt down all leafs in the flow to find where spell_94 and item_d4 should be set to null?
- Refactor just the resetting of these two properties to null before/after/during this Case 2 / onSelection in ListMenu proper?
- Use this fix for now / put in onSelection and reset spell_94 in itemlist and spelllist
- Implement an MP check for ItemListMenu and SpellListMenu (where only SpellListMenu will have any functionality)?


Technically item_d4 doesn't need to be reset to null but it is used in the same manner as spell_94 and should follow the same conventions. item_d4 is also suffering from the same stale/garbage data but since there's no validations (like MP) its not a concern (yet).