### PR TITLE
Render overhaul part 87

### DIFF
--- a/gfx/shaders/battle_tmd.fsh
+++ b/gfx/shaders/battle_tmd.fsh
@@ -92,7 +92,7 @@ void main() {
   outColour.rgb *= recolour;
 
   // The or condition is to disable translucency if a texture's pixel has alpha disabled
-  if(translucencyMode == 0 && (!textured || outColour.a != 0)) { // (B+F)/2 translucency
+  if(translucencyMode == 1 && (!textured || outColour.a != 0)) { // (B+F)/2 translucency
     outColour.a = 0.5;
   } else {
     outColour.a = 1.0;

--- a/gfx/shaders/tmd.fsh
+++ b/gfx/shaders/tmd.fsh
@@ -89,7 +89,7 @@ void main() {
   outColour.rgb *= recolour;
 
   // The or condition is to disable translucency if a texture's pixel has alpha disabled
-  if(translucencyMode == 0 && (!textured || outColour.a != 0)) { // (B+F)/2 translucency
+  if(translucencyMode == 1 && (!textured || outColour.a != 0)) { // (B+F)/2 translucency
     outColour.a = 0.5;
   } else {
     outColour.a = 1.0;

--- a/src/main/java/legend/core/QueuedModel.java
+++ b/src/main/java/legend/core/QueuedModel.java
@@ -16,6 +16,7 @@ import java.nio.FloatBuffer;
 import java.util.Arrays;
 
 import static legend.core.GameEngine.GPU;
+import static org.lwjgl.opengl.GL11C.GL_LEQUAL;
 import static org.lwjgl.opengl.GL11C.GL_LESS;
 
 public abstract class QueuedModel<Options extends ShaderOptionsBase<Options>, T extends QueuedModel<Options, T>> {
@@ -184,7 +185,7 @@ public abstract class QueuedModel<Options extends ShaderOptionsBase<Options>, T 
     this.texturesUsed = false;
     this.worldScissor.set(this.batch.engine.scissorStack.top());
     this.opaqueDepthComparator = GL_LESS;
-    this.translucentDepthComparator = GL_LESS;
+    this.translucentDepthComparator = GL_LEQUAL;
   }
 
   void setTransforms(final MV transforms) {

--- a/src/main/java/legend/core/QueuedModelBattleTmd.java
+++ b/src/main/java/legend/core/QueuedModelBattleTmd.java
@@ -155,6 +155,15 @@ public class QueuedModelBattleTmd extends QueuedModel<ShaderOptionsBattleTmd, Qu
   }
 
   @Override
+  public boolean shouldRender(@Nullable final Translucency translucency, final int layer) {
+    if(this.hasTranslucency() && (!this.obj.hasTexture() || this.isUniformLit())) {
+      return translucency != null && this.tmdTranslucency == translucency.ordinal();
+    }
+
+    return super.shouldRender(translucency, layer) || (this.ctmdFlags & 0x2) != 0 && translucency != null && this.tmdTranslucency == translucency.ordinal();
+  }
+
+  @Override
   void storeTransforms(final int modelIndex, final FloatBuffer transforms2Buffer) {
     super.storeTransforms(modelIndex, transforms2Buffer);
 
@@ -166,14 +175,14 @@ public class QueuedModelBattleTmd extends QueuedModel<ShaderOptionsBattleTmd, Qu
   }
 
   @Override
-  void render(@Nullable final Translucency translucency) {
+  void render(@Nullable final Translucency translucency, final int layer) {
     if(this.isTranslucent() || this.obj.hasTranslucency() && (!this.obj.hasTexture() || this.isUniformLit())) {
       // Translucency override
       this.updateColours(translucency);
-      this.obj.render(this.startVertex, this.vertexCount);
+      this.obj.render(layer, this.startVertex, this.vertexCount);
       return;
     }
 
-    super.render(translucency);
+    super.render(translucency, layer);
   }
 }

--- a/src/main/java/legend/core/QueuedModelStandard.java
+++ b/src/main/java/legend/core/QueuedModelStandard.java
@@ -64,7 +64,16 @@ public class QueuedModelStandard extends QueuedModel<ShaderOptionsStandard, Queu
   }
 
   @Override
-  void render(@Nullable final Translucency translucency) {
+  public boolean shouldRender(@Nullable final Translucency translucency, final int layer) {
+    if(this.hasTranslucencyOverride) {
+      return this.translucency == translucency;
+    }
+
+    return super.shouldRender(translucency, layer);
+  }
+
+  @Override
+  void render(@Nullable final Translucency translucency, final int layer) {
     if(translucency != null) {
       this.shaderOptions.translucency(translucency);
     } else {
@@ -77,10 +86,10 @@ public class QueuedModelStandard extends QueuedModel<ShaderOptionsStandard, Queu
     if(this.hasTranslucencyOverride) {
       // Translucency override
       this.updateColours(translucency);
-      this.obj.render(this.startVertex, this.vertexCount);
+      this.obj.render(layer, this.startVertex, this.vertexCount);
       return;
     }
 
-    super.render(translucency);
+    super.render(translucency, layer);
   }
 }

--- a/src/main/java/legend/core/QueuedModelTmd.java
+++ b/src/main/java/legend/core/QueuedModelTmd.java
@@ -95,6 +95,15 @@ public class QueuedModelTmd extends QueuedModel<ShaderOptionsTmd, QueuedModelTmd
   }
 
   @Override
+  public boolean shouldRender(@Nullable final Translucency translucency, final int layer) {
+    if(this.hasTranslucency() && !this.obj.hasTexture()) {
+      return translucency != null && this.tmdTranslucency == translucency.ordinal();
+    }
+
+    return super.shouldRender(translucency, layer);
+  }
+
+  @Override
   void storeTransforms(final int modelIndex, final FloatBuffer transforms2Buffer) {
     super.storeTransforms(modelIndex, transforms2Buffer);
 
@@ -106,14 +115,14 @@ public class QueuedModelTmd extends QueuedModel<ShaderOptionsTmd, QueuedModelTmd
   }
 
   @Override
-  void render(@Nullable final Translucency translucency) {
+  void render(@Nullable final Translucency translucency, final int layer) {
     if(this.obj.hasTranslucency() && !this.obj.hasTexture()) {
       // Translucency override
       this.updateColours(translucency);
-      this.obj.render(this.startVertex, this.vertexCount);
+      this.obj.render(layer, this.startVertex, this.vertexCount);
       return;
     }
 
-    super.render(translucency);
+    super.render(translucency, layer);
   }
 }

--- a/src/main/java/legend/core/RenderEngine.java
+++ b/src/main/java/legend/core/RenderEngine.java
@@ -60,6 +60,7 @@ import static legend.core.GameEngine.GTE;
 import static legend.core.MathHelper.PI;
 import static legend.core.MathHelper.clamp;
 import static legend.game.Scus94491BpeSegment_8004.currentEngineState_8004dd04;
+import static legend.game.Scus94491BpeSegment_800c.worldToScreenMatrix_800c3548;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_A;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_D;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_ESCAPE;
@@ -79,12 +80,9 @@ import static org.lwjgl.opengl.GL11C.GL_BLEND;
 import static org.lwjgl.opengl.GL11C.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11C.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11C.GL_DEPTH_COMPONENT;
-import static org.lwjgl.opengl.GL11C.GL_DEPTH_TEST;
 import static org.lwjgl.opengl.GL11C.GL_FILL;
 import static org.lwjgl.opengl.GL11C.GL_FLOAT;
 import static org.lwjgl.opengl.GL11C.GL_FRONT_AND_BACK;
-import static org.lwjgl.opengl.GL11C.GL_LEQUAL;
-import static org.lwjgl.opengl.GL11C.GL_LESS;
 import static org.lwjgl.opengl.GL11C.GL_LINE;
 import static org.lwjgl.opengl.GL11C.GL_LINEAR;
 import static org.lwjgl.opengl.GL11C.GL_LINE_SMOOTH;
@@ -96,7 +94,6 @@ import static org.lwjgl.opengl.GL11C.GL_TRIANGLES;
 import static org.lwjgl.opengl.GL11C.GL_UNSIGNED_BYTE;
 import static org.lwjgl.opengl.GL11C.glClear;
 import static org.lwjgl.opengl.GL11C.glClearColor;
-import static org.lwjgl.opengl.GL11C.glDepthFunc;
 import static org.lwjgl.opengl.GL11C.glDepthMask;
 import static org.lwjgl.opengl.GL11C.glDisable;
 import static org.lwjgl.opengl.GL11C.glEnable;
@@ -294,7 +291,7 @@ public class RenderEngine {
   public RenderEngine() {
     this.mainBatch = new RenderBatch(this, () -> this.vdfUniform, this.vdfBuffer, this.lightBuffer);
     this.scissorStack = new ScissorStack(this, this.mainBatch);
-    this.state = new RenderState(this, this.scissorStack);
+    this.state = new RenderState(this);
   }
 
   /**
@@ -663,7 +660,7 @@ public class RenderEngine {
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
         // set render states
-        glDisable(GL_DEPTH_TEST);
+        this.state.disableDepthTest();
         glDepthMask(true); // enable depth writes so glClear won't ignore clearing the depth buffer
         glDisable(GL_BLEND);
 
@@ -756,10 +753,6 @@ public class RenderEngine {
       return;
     }
 
-    // Render if the depth is less than what is currently in the depth buffer
-    glEnable(GL_DEPTH_TEST);
-    glDepthFunc(GL_LESS);
-
     // Update the depth mask so nothing further away than this will render
     glDepthMask(true);
 
@@ -782,27 +775,30 @@ public class RenderEngine {
 
       final QueuedModel<?, ?> entry = pool.get(i);
       entry.useShader(modelIndex, 1);
+      this.state.enableDepthTest(entry.opaqueDepthComparator);
 
       this.state.scissor(entry);
 
-      if(entry.shouldRender(null)) {
-        if(backFaceCulling) {
-          this.state.backfaceCulling(entry.obj.useBackfaceCulling());
+      for(int layer = 0; layer < entry.getLayers(); layer++) {
+        if(entry.shouldRender(null, layer)) {
+          if(backFaceCulling) {
+            this.state.backfaceCulling(entry.obj.useBackfaceCulling());
+          }
+
+          entry.useTexture();
+          entry.render(null, layer);
         }
 
-        entry.useTexture();
-        entry.render(null);
-      }
+        // First pass of translucency rendering - renders opaque pixels with translucency bit not set for translucent primitives
+        if(entry.hasTranslucency()) {
+          for(int translucencyIndex = 0; translucencyIndex < Translucency.FOR_RENDERING.length; translucencyIndex++) {
+            final Translucency translucency = Translucency.FOR_RENDERING[translucencyIndex];
 
-      // First pass of translucency rendering - renders opaque pixels with translucency bit not set for translucent primitives
-      if(entry.hasTranslucency()) {
-        for(int translucencyIndex = 0; translucencyIndex < Translucency.FOR_RENDERING.length; translucencyIndex++) {
-          final Translucency translucency = Translucency.FOR_RENDERING[translucencyIndex];
-
-          if(entry.shouldRender(translucency)) {
-            this.state.backfaceCulling(false);
-            entry.useTexture();
-            entry.render(translucency);
+            if(entry.shouldRender(translucency, layer)) {
+              this.state.backfaceCulling(false);
+              entry.useTexture();
+              entry.render(translucency, layer);
+            }
           }
         }
       }
@@ -818,8 +814,6 @@ public class RenderEngine {
 
     // Do not update the depth mask so that we don't prevent things further away than this from rendering
     glDepthMask(false);
-    glEnable(GL_DEPTH_TEST);
-    glDepthFunc(GL_LEQUAL);
 
     glEnable(GL_BLEND);
 
@@ -840,29 +834,32 @@ public class RenderEngine {
 
       if(entry.hasTranslucency()) {
         entry.useShader(modelIndex, 2);
+        this.state.enableDepthTest(entry.translucentDepthComparator);
 
         this.state.scissor(entry);
 
         entry.useTexture();
 
-        if(entry.shouldRender(Translucency.HALF_B_PLUS_HALF_F)) {
-          Translucency.HALF_B_PLUS_HALF_F.setGlState();
-          entry.render(Translucency.HALF_B_PLUS_HALF_F);
-        }
+        for(int layer = 0; layer < entry.getLayers(); layer++) {
+          if(entry.shouldRender(Translucency.HALF_B_PLUS_HALF_F, layer)) {
+            Translucency.HALF_B_PLUS_HALF_F.setGlState();
+            entry.render(Translucency.HALF_B_PLUS_HALF_F, layer);
+          }
 
-        if(entry.shouldRender(Translucency.B_PLUS_F)) {
-          Translucency.B_PLUS_F.setGlState();
-          entry.render(Translucency.B_PLUS_F);
-        }
+          if(entry.shouldRender(Translucency.B_PLUS_F, layer)) {
+            Translucency.B_PLUS_F.setGlState();
+            entry.render(Translucency.B_PLUS_F, layer);
+          }
 
-        if(entry.shouldRender(Translucency.B_MINUS_F)) {
-          Translucency.B_MINUS_F.setGlState();
-          entry.render(Translucency.B_MINUS_F);
-        }
+          if(entry.shouldRender(Translucency.B_MINUS_F, layer)) {
+            Translucency.B_MINUS_F.setGlState();
+            entry.render(Translucency.B_MINUS_F, layer);
+          }
 
-        if(entry.shouldRender(Translucency.B_PLUS_QUARTER_F)) {
-          Translucency.B_PLUS_F.setGlState();
-          entry.render(Translucency.B_PLUS_QUARTER_F);
+          if(entry.shouldRender(Translucency.B_PLUS_QUARTER_F, layer)) {
+            Translucency.B_PLUS_F.setGlState();
+            entry.render(Translucency.B_PLUS_QUARTER_F, layer);
+          }
         }
       }
     }
@@ -871,26 +868,38 @@ public class RenderEngine {
   private void handleMovement() {
     if(this.movingLeft) {
       this.camera3d.strafe(-MOVE_SPEED * 200);
+      this.camera3d.getView().get3x3(worldToScreenMatrix_800c3548);
+      this.camera3d.getView().getTranslation(worldToScreenMatrix_800c3548.transfer);
     }
 
     if(this.movingRight) {
       this.camera3d.strafe(MOVE_SPEED * 200);
+      this.camera3d.getView().get3x3(worldToScreenMatrix_800c3548);
+      this.camera3d.getView().getTranslation(worldToScreenMatrix_800c3548.transfer);
     }
 
     if(this.movingForward) {
       this.camera3d.move(-MOVE_SPEED * 200);
+      this.camera3d.getView().get3x3(worldToScreenMatrix_800c3548);
+      this.camera3d.getView().getTranslation(worldToScreenMatrix_800c3548.transfer);
     }
 
     if(this.movingBackward) {
       this.camera3d.move(MOVE_SPEED * 200);
+      this.camera3d.getView().get3x3(worldToScreenMatrix_800c3548);
+      this.camera3d.getView().getTranslation(worldToScreenMatrix_800c3548.transfer);
     }
 
     if(this.movingUp) {
       this.camera3d.jump(-MOVE_SPEED * 200);
+      this.camera3d.getView().get3x3(worldToScreenMatrix_800c3548);
+      this.camera3d.getView().getTranslation(worldToScreenMatrix_800c3548.transfer);
     }
 
     if(this.movingDown) {
       this.camera3d.jump(MOVE_SPEED * 200);
+      this.camera3d.getView().get3x3(worldToScreenMatrix_800c3548);
+      this.camera3d.getView().getTranslation(worldToScreenMatrix_800c3548.transfer);
     }
   }
 
@@ -1126,6 +1135,8 @@ public class RenderEngine {
       this.lastY = y;
 
       this.camera3d.look(-this.yaw, -this.pitch);
+      this.camera3d.getView().get3x3(worldToScreenMatrix_800c3548);
+      this.camera3d.getView().getTranslation(worldToScreenMatrix_800c3548.transfer);
     }
   }
 

--- a/src/main/java/legend/core/opengl/MeshObj.java
+++ b/src/main/java/legend/core/opengl/MeshObj.java
@@ -72,26 +72,26 @@ public class MeshObj extends Obj {
   }
 
   @Override
-  public void render(final int startVertex, final int vertexCount) {
-    for(int i = 0; i < this.meshes.length; i++) {
-      this.meshes[i].draw(startVertex, vertexCount);
-    }
+  public boolean shouldRender(@Nullable final Translucency translucency, final int layer) {
+    return this.meshes[layer].translucencyMode == translucency;
   }
 
   @Override
-  public void render(@Nullable final Translucency translucency, final int startVertex, final int vertexCount) {
-    if(translucency == null) {
-      for(int i = 0; i < this.meshes.length; i++) {
-        if(!this.meshes[i].translucent) {
-          this.meshes[i].draw(startVertex, vertexCount);
-        }
-      }
-    } else {
-      for(int i = 0; i < this.meshes.length; i++) {
-        if(this.meshes[i].translucent && this.meshes[i].translucencyMode == translucency) {
-          this.meshes[i].draw(startVertex, vertexCount);
-        }
-      }
+  public int getLayers() {
+    return this.meshes.length;
+  }
+
+  @Override
+  public void render(final int layer, final int startVertex, final int vertexCount) {
+    this.meshes[layer].draw(startVertex, vertexCount);
+  }
+
+  @Override
+  public void render(@Nullable final Translucency translucency, final int layer, final int startVertex, final int vertexCount) {
+    final Mesh mesh = this.meshes[layer];
+
+    if(!mesh.translucent && translucency == null || mesh.translucent && mesh.translucencyMode == translucency) {
+      mesh.draw(startVertex, vertexCount);
     }
   }
 

--- a/src/main/java/legend/core/opengl/Obj.java
+++ b/src/main/java/legend/core/opengl/Obj.java
@@ -66,8 +66,10 @@ public abstract class Obj {
   public abstract boolean hasTexture();
   public abstract boolean hasTranslucency();
   public abstract boolean shouldRender(@Nullable final Translucency translucency);
-  public abstract void render(final int startVertex, final int vertexCount);
-  public abstract void render(@Nullable final Translucency translucency, final int startVertex, final int vertexCount);
+  public abstract boolean shouldRender(@Nullable final Translucency translucency, final int layer);
+  public abstract int getLayers();
+  public abstract void render(final int layer, final int startVertex, final int vertexCount);
+  public abstract void render(@Nullable final Translucency translucency, final int layer, final int startVertex, final int vertexCount);
 
   @Override
   public String toString() {

--- a/src/main/java/legend/core/opengl/RenderState.java
+++ b/src/main/java/legend/core/opengl/RenderState.java
@@ -8,7 +8,9 @@ import legend.game.modding.coremod.CoreMod;
 
 import static legend.core.GameEngine.CONFIG;
 import static org.lwjgl.opengl.GL11C.GL_CULL_FACE;
+import static org.lwjgl.opengl.GL11C.GL_DEPTH_TEST;
 import static org.lwjgl.opengl.GL11C.GL_SCISSOR_TEST;
+import static org.lwjgl.opengl.GL11C.glDepthFunc;
 import static org.lwjgl.opengl.GL11C.glDisable;
 import static org.lwjgl.opengl.GL11C.glEnable;
 import static org.lwjgl.opengl.GL11C.glScissor;
@@ -22,14 +24,15 @@ public class RenderState {
   private float w;
   private float h;
 
-  private final ScissorStack scissorStack;
   private final Rect4i tempScissorRect = new Rect4i();
   private final Rect4i activeScissorRect = new Rect4i();
   private boolean scissor;
 
-  public RenderState(final RenderEngine engine, final ScissorStack scissorStack) {
+  private boolean depthTest;
+  private int depthComparator;
+
+  public RenderState(final RenderEngine engine) {
     this.engine = engine;
-    this.scissorStack = scissorStack;
   }
 
   public void initBatch(final RenderBatch batch) {
@@ -54,6 +57,25 @@ public class RenderState {
       } else {
         glDisable(GL_CULL_FACE);
       }
+    }
+  }
+
+  public void enableDepthTest(final int comparator) {
+    if(!this.depthTest) {
+      glEnable(GL_DEPTH_TEST);
+      this.depthTest = true;
+    }
+
+    if(this.depthComparator != comparator) {
+      glDepthFunc(comparator);
+      this.depthComparator = comparator;
+    }
+  }
+
+  public void disableDepthTest() {
+    if(this.depthTest) {
+      glDisable(GL_DEPTH_TEST);
+      this.depthTest = false;
     }
   }
 

--- a/src/main/java/legend/core/opengl/TextObj.java
+++ b/src/main/java/legend/core/opengl/TextObj.java
@@ -28,12 +28,22 @@ public class TextObj extends Obj {
   }
 
   @Override
-  public void render(final int startVertex, final int vertexCount) {
+  public boolean shouldRender(@Nullable final Translucency translucency, final int layer) {
+    return this.shouldRender(translucency);
+  }
+
+  @Override
+  public int getLayers() {
+    return 1;
+  }
+
+  @Override
+  public void render(final int layer, final int startVertex, final int vertexCount) {
     this.mesh.draw(startVertex, vertexCount);
   }
 
   @Override
-  public void render(@Nullable final Translucency translucency, final int startVertex, final int vertexCount) {
+  public void render(@Nullable final Translucency translucency, final int layer, final int startVertex, final int vertexCount) {
     this.mesh.draw(startVertex, vertexCount);
   }
 

--- a/src/main/java/legend/core/opengl/TmdMeshObj.java
+++ b/src/main/java/legend/core/opengl/TmdMeshObj.java
@@ -18,4 +18,9 @@ public class TmdMeshObj extends MeshObj {
     // For untextured translucent faces, no translucency is defined in the TMD data and will be passed in at runtime via tmdGp0Tpage_1f8003ec
     return super.shouldRender(translucency) || translucency != null && this.translucencies.isEmpty();
   }
+
+  @Override
+  public boolean shouldRender(@Nullable final Translucency translucency, final int layer) {
+    return super.shouldRender(translucency, layer) || translucency != null && this.translucencies.isEmpty();
+  }
 }

--- a/src/main/java/legend/core/opengl/TmdObjLoader.java
+++ b/src/main/java/legend/core/opengl/TmdObjLoader.java
@@ -13,6 +13,7 @@ import legend.game.types.Translucency;
 import org.joml.Vector3f;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static legend.game.Scus94491BpeSegment.tmdGp0CommandId_1f8003ee;
@@ -289,7 +290,9 @@ public final class TmdObjLoader {
       meshes[meshIndex++] = createMesh(tmdMeshes.translucent[i], vertexSize);
     }
 
-    return new TmdMeshObj(name, meshes, backfaceCulling);
+    final Mesh[] reversed = new Mesh[meshes.length];
+    Arrays.setAll(reversed, i -> meshes[meshes.length - i - 1]);
+    return new TmdMeshObj(name, reversed, backfaceCulling);
   }
 
   private static Mesh createMesh(final TmdObjLoaderMesh tmdMesh, final int vertexSize) {

--- a/src/main/java/legend/game/Scus94491BpeSegment_8002.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8002.java
@@ -152,6 +152,7 @@ import static legend.game.Scus94491BpeSegment_800b.transitioningFromCombatToSubm
 import static legend.game.Scus94491BpeSegment_800b.uiFile_800bdc3c;
 import static legend.game.Scus94491BpeSegment_800b.whichMenu_800bdc38;
 import static legend.game.Scus94491BpeSegment_800e.main;
+import static org.lwjgl.opengl.GL11C.GL_LEQUAL;
 
 public final class Scus94491BpeSegment_8002 {
   private Scus94491BpeSegment_8002() { }
@@ -1420,10 +1421,14 @@ public final class Scus94491BpeSegment_8002 {
               .queueOrthoModel(renderable.uiType_20.obj, transforms, QueuedModelStandard.class)
               .vertices(metrics.vertexStart, 4)
               .tpageOverride(tpageX, (tpage & 0b10000) != 0 ? 256 : 0)
-              .clutOverride(clutX, clut >>> 6);
+              .clutOverride(clutX, clut >>> 6)
+            ;
 
             if((metrics.clut_04 & 0x8000) != 0) {
-              model.translucency(Translucency.of(tpage >>> 5 & 0b11));
+              model
+                .translucency(Translucency.of(tpage >>> 5 & 0b11))
+                .translucentDepthComparator(GL_LEQUAL)
+              ;
             }
 
             if(renderable.widthCut != 0 || renderable.heightCut != 0) {

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -156,6 +156,7 @@ import static legend.game.Scus94491BpeSegment_800b.whichMenu_800bdc38;
 import static legend.game.Scus94491BpeSegment_800c.lightColourMatrix_800c3508;
 import static legend.game.Scus94491BpeSegment_800c.lightDirectionMatrix_800c34e8;
 import static legend.game.Scus94491BpeSegment_800c.worldToScreenMatrix_800c3548;
+import static org.lwjgl.opengl.GL11C.GL_LESS;
 import static org.lwjgl.opengl.GL11C.GL_LINES;
 import static org.lwjgl.opengl.GL11C.GL_TRIANGLE_STRIP;
 
@@ -933,7 +934,10 @@ public class SMap extends EngineState {
             .lightDirection(lightDirectionMatrix_800c34e8)
             .lightColour(lightColourMatrix_800c3508)
             .backgroundColour(GTE.backgroundColour)
-            .tmdTranslucency(tmdGp0Tpage_1f8003ec >>> 5 & 0b11);
+            .tmdTranslucency(tmdGp0Tpage_1f8003ec >>> 5 & 0b11)
+            // Fix for chest shadow rendering on top of lid (GH#1408)
+            .translucentDepthComparator(GL_LESS)
+          ;
 
           if(texture != null) {
             queue.texture(texture);


### PR DESCRIPTION
### Change A
(B+F)/2 translucency for TMDs was just broken, used 100% alpha instead of 50%

### Change B
Added depth culling comparison option to queued models. I had changed it from GL_LESS to GL_LEQUAL a while ago to fix UI rendering, and that actually fixed some other things (like fixing Haschel's face textures not rendering) but also broke other things (chest shadow rendering overtop of open lid). I'm still defauling to GL_LEQUAL, but using GL_LESS for sobj models. No idea if this is breaking/fixing anything else. Turns out retail models are a mess of overlapping geometry.

### Change C
Overhauled render engine to give it full control over rendering individual layers of models. Before, it worked like this:
1. Render all opaque layers (opaque)
2. Render all translucent layers with translucent texture bit disabled (opaque)
3. Render all translucent layers with translucent texture bit enabled (translucent)

This was causing Haschel's face texture to get depth culled because it was rendered at the same depth as his head model. The head was always rendered first. The fix was two parts:
1. Change the TMD loader to load meshes in the OPPOSITE order to mimic the order they would be rendered when sent to the GPU's queue (LIFO)
2. Combine steps 1 and 2 of the previous list, so the layers are rendered in order (instead of `all layers that meet X criteria` then `all layers that meet Y criteria`

### Change D
Made freecam work in old renderer for testing