### PR TITLE
Player/geometry collision handling

### DIFF
--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -116,9 +116,9 @@ public class CollisionGeometry {
    * @return Collision primitive index that this model is within
    */
   @Method(0x800e88a0L)
-  public int handlePlayerOrNpcMovementAndCollision(final boolean isNpc, final Vector3f position, final Vector3f movement) {
+  public int checkCollision(final boolean isNpc, final Vector3f position, final Vector3f movement) {
     if(isNpc) {
-      return this.handleSobjMovementAndCollision(position.x, position.y, position.z, movement);
+      return this.handleCollision(position.x, position.y, position.z, movement);
     }
 
     //LAB_800e88d8
@@ -128,7 +128,7 @@ public class CollisionGeometry {
       this.playerRunning = movement.x * movement.x + movement.z * movement.z > 64.0f;
 
       //LAB_800e8908
-      this.collidedPrimitiveIndex_800cbd94 = this.handleSobjMovementAndCollision(position.x, position.y, position.z, movement);
+      this.collidedPrimitiveIndex_800cbd94 = this.handleCollision(position.x, position.y, position.z, movement);
       this.cachedPlayerMovement_800cbd98.set(movement);
 
       if(this.collidedPrimitiveIndex_800cbd94 != -1) {
@@ -176,7 +176,7 @@ public class CollisionGeometry {
   }
 
   @Method(0x800e8b40L)
-  private void FUN_800e8b40(FileData a1) {
+  private void loadCollisionInfo(FileData a1) {
     if(a1.size() < this.primitiveCount_0c * 5 * 0xc) {
       LOGGER.warn("Submap file too short, padding with 0's");
       final byte[] newData = new byte[this.primitiveCount_0c * 5 * 0xc];
@@ -216,7 +216,7 @@ public class CollisionGeometry {
     this.dobj2Ptr_20.attribute_00 = 0x4000_0000;
 
     this.loadCollisionModel(tmd);
-    this.FUN_800e8b40(a2);
+    this.loadCollisionInfo(a2);
 
     this.collisionLoaded_800f7f14 = true;
 
@@ -380,7 +380,7 @@ public class CollisionGeometry {
    * @return Collision primitive index that this model is within
    */
   @Method(0x800e9430L)
-  private int handleSobjMovementAndCollision(final float x, final float y, final float z, final Vector3f movement) {
+  private int handleCollision(final float x, final float y, final float z, final Vector3f movement) {
     if(this.smap.smapLoadingStage_800cb430 != SubmapState.RENDER_SUBMAP_12 && this.smap.smapLoadingStage_800cb430 != SubmapState.WAIT_FOR_FADE_IN) {
       return -1;
     }

--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -434,19 +434,20 @@ public class CollisionGeometry {
       final CollisionPrimitiveInfo0c destinationPrimitive = this.primitiveInfo_14[destinationPrimitiveIndex];
 
       //LAB_800e9b50
-      int v0 = -1;
+      // Check if movement would place Dart within 10 units of a boundary
+      int nearBoundary = -1;
       for(int vertexIndex = 0; vertexIndex < destinationPrimitive.vertexCount_00; vertexIndex++) {
         final CollisionVertexInfo0c vertexInfo = this.vertexInfo_18[destinationPrimitive.vertexInfoOffset_02 + vertexIndex];
         if(vertexInfo._08 && Math.abs((vertexInfo.x_00 * endX + vertexInfo.z_02 * endZ + vertexInfo._04) / 0x400) < 10) {
-          v0 = vertexIndex;
+          nearBoundary = vertexIndex;
           break;
         }
       }
 
-      if(v0 == -1) {
+      if(nearBoundary == -1) {
         final Vector3f normal = this.normals_08[destinationPrimitiveIndex];
 
-        // This causes Dart to move up/down a slope
+        // This allows Dart to move up/down a moderate slope
         if(Math.abs(y + (normal.x * endX + normal.z * endZ + destinationPrimitive._08) / normal.y) < 50) {
           //LAB_800e9e64
           movement.y = -(normal.x * (x + movement.x) + normal.z * (z + movement.z) + destinationPrimitive._08) / normal.y;
@@ -460,14 +461,15 @@ public class CollisionGeometry {
     }
 
     //LAB_800e9c58
-    // This disables "sliding" along collision boundaries if you're standing in a shop/inn primitive
+    // This disables forced parallel movement along collision boundaries if you're standing in a shop/inn primitive
     if((this.getCollisionAndTransitionInfo(currentPrimitiveIndex) & 0x20) != 0) {
       return -1;
     }
 
     //LAB_800e9ca0
-    int a1 = -1;
-    for(int i = 1; i < 4 && a1 == -1; i++) {
+    // Check if movement would place Dart out of bounds
+    int onBoundary = -1;
+    for(int i = 1; i < 4 && onBoundary == -1; i++) {
       final float endX2 = x + movement.x * i;
       final float endZ2 = z + movement.z * i;
 
@@ -476,18 +478,18 @@ public class CollisionGeometry {
         final CollisionVertexInfo0c vertexInfo = this.vertexInfo_18[this.primitiveInfo_14[currentPrimitiveIndex].vertexInfoOffset_02 + vertexIndex];
 
         if(vertexInfo._08 && (vertexInfo.x_00 * endX2 + vertexInfo.z_02 * endZ2 + vertexInfo._04) / 0x400 <= 0) {
-          a1 = vertexIndex;
+          onBoundary = vertexIndex;
           break;
         }
       }
     }
 
-    // Handle sliding along collision
-    if(a1 != -1) {
+    // Handle forced parallel movement along boundary
+    if(onBoundary != -1) {
       //LAB_800e9e78
 
       //LAB_800e9e7c
-      final CollisionVertexInfo0c vertexInfo = this.vertexInfo_18[this.primitiveInfo_14[currentPrimitiveIndex].vertexInfoOffset_02 + a1];
+      final CollisionVertexInfo0c vertexInfo = this.vertexInfo_18[this.primitiveInfo_14[currentPrimitiveIndex].vertexInfoOffset_02 + onBoundary];
       final float angle1 = MathHelper.atan2(endZ - z, endX - x);
       float angle2 = MathHelper.atan2(-vertexInfo.x_00, vertexInfo.z_02);
       float angleDeltaAbs = Math.abs(angle1 - angle2);
@@ -496,9 +498,9 @@ public class CollisionGeometry {
       }
 
       //LAB_800e9f38
-      // About 73 to 107 degrees (90 +- 17)
+      // Stop if movement is nearly perpendicular (73 to 107 degrees) towards the boundary
       final float baseAngle = MathHelper.PI / 2.0f; // 90 degrees
-      final float deviation = 0.29670597283903602807702743064306f; // 17 degrees
+      final float deviation = 0.29670597283903602807702743064306f; // (+/-) 17 degrees
       if(angleDeltaAbs >= baseAngle - deviation && angleDeltaAbs <= baseAngle + deviation) {
         return -1;
       }
@@ -555,6 +557,7 @@ public class CollisionGeometry {
       //LAB_800ea234
       final Vector3f normal = this.normals_08[s2];
 
+      // Prevent moving up/down a steep slope
       if(Math.abs(y + (normal.x * offsetX + normal.z * offsetZ + this.primitiveInfo_14[s2]._08) / normal.y) >= 50) {
         return -1;
       }
@@ -572,6 +575,7 @@ public class CollisionGeometry {
 
     final Vector3f normal = this.normals_08[destinationPrimitiveIndex];
 
+    // Prevent moving up/down a steep slope
     if(Math.abs(y + (normal.x * endX + normal.z * endZ + this.primitiveInfo_14[destinationPrimitiveIndex]._08) / normal.y) >= 50) {
       return -1;
     }

--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -47,10 +47,10 @@ public class CollisionGeometry {
 
   private final int[] collisionPrimitiveIndices_800cbe48 = new int[8];
 
-  public float dartRotationAfterCollision_800d1a84;
+  public float playerRotationAfterCollision_800d1a84;
   /** Converted to an int so we can count how many frames it should be active for 60 FPS */
-  public int dartRotationWasUpdated_800d1a8c;
-  public boolean dartRunning;
+  public int playerRotationWasUpdated_800d1a8c;
+  public boolean playerRunning;
 
   private boolean collisionLoaded_800f7f14;
 
@@ -125,16 +125,16 @@ public class CollisionGeometry {
     if(!this.playerCollisionLatch_800cbe34) {
       this.playerCollisionLatch_800cbe34 = true;
 
-      this.dartRunning = movement.x * movement.x + movement.z * movement.z > 64.0f;
+      this.playerRunning = movement.x * movement.x + movement.z * movement.z > 64.0f;
 
       //LAB_800e8908
       this.collidedPrimitiveIndex_800cbd94 = this.handleMovementAndCollision(position.x, position.y, position.z, movement);
       this.cachedPlayerMovement_800cbd98.set(movement);
 
       if(this.collidedPrimitiveIndex_800cbd94 != -1) {
-        if(this.dartRotationWasUpdated_800d1a8c == 0) {
-          this.dartRotationWasUpdated_800d1a8c = this.smap.tickMultiplier();
-          this.dartRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(movement.x, movement.z) + MathHelper.PI, MathHelper.TWO_PI);
+        if(this.playerRotationWasUpdated_800d1a8c == 0) {
+          this.playerRotationWasUpdated_800d1a8c = this.smap.tickMultiplier();
+          this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(movement.x, movement.z) + MathHelper.PI, MathHelper.TWO_PI);
         }
       }
     } else {
@@ -240,8 +240,8 @@ public class CollisionGeometry {
   public void tick() {
     this.playerCollisionLatch_800cbe34 = false;
 
-    if(this.dartRotationWasUpdated_800d1a8c > 0) {
-      this.dartRotationWasUpdated_800d1a8c--;
+    if(this.playerRotationWasUpdated_800d1a8c > 0) {
+      this.playerRotationWasUpdated_800d1a8c--;
     }
   }
 
@@ -434,7 +434,7 @@ public class CollisionGeometry {
       final CollisionPrimitiveInfo0c destinationPrimitive = this.primitiveInfo_14[destinationPrimitiveIndex];
 
       //LAB_800e9b50
-      // Check if movement would place Dart within 10 units of a boundary
+      // Check if movement would place the sObj within 10 units of a boundary
       int nearBoundary = -1;
       for(int vertexIndex = 0; vertexIndex < destinationPrimitive.vertexCount_00; vertexIndex++) {
         final CollisionVertexInfo0c vertexInfo = this.vertexInfo_18[destinationPrimitive.vertexInfoOffset_02 + vertexIndex];
@@ -447,7 +447,7 @@ public class CollisionGeometry {
       if(nearBoundary == -1) {
         final Vector3f normal = this.normals_08[destinationPrimitiveIndex];
 
-        // This allows Dart to move up/down a moderate slope
+        // This allows the sObj to move up/down a moderate slope
         if(Math.abs(y + (normal.x * endX + normal.z * endZ + destinationPrimitive._08) / normal.y) < 50) {
           //LAB_800e9e64
           movement.y = -(normal.x * (x + movement.x) + normal.z * (z + movement.z) + destinationPrimitive._08) / normal.y;
@@ -467,7 +467,7 @@ public class CollisionGeometry {
     }
 
     //LAB_800e9ca0
-    // Check if movement would place Dart out of bounds
+    // Check if movement would place the sObj out of bounds
     int onBoundary = -1;
     for(int i = 1; i < 4 && onBoundary == -1; i++) {
       final float endX2 = x + movement.x * i;
@@ -530,15 +530,15 @@ public class CollisionGeometry {
       final float angleStep = 0.09817477f * direction; // 5.625 degrees
 
       //LAB_800e9fd0
-      angle2 -= angleStep;
+      //angle2 -= angleStep;
 
       //LAB_800e9ff4
+      // Adjust approach angle until new destination is in-bounds
+      // Stop movement if +/- 45 degrees would still place the sObj out of bounds
       int s2 = -1;
       float offsetX = 0.0f;
       float offsetZ = 0.0f;
-      for(int i = 0; i < 8 && s2 == -1; i++) {
-        angle2 += angleStep;
-
+      for(int i = 0; i < 8 && s2 == -1; i++, angle2 += angleStep) {
         final float sin = MathHelper.sin(angle2);
         final float cos = MathHelper.cosFromSin(sin, angle2);
         offsetX = x + cos * distanceMultiplier;

--- a/src/main/java/legend/game/submap/CollisionVertexInfo0c.java
+++ b/src/main/java/legend/game/submap/CollisionVertexInfo0c.java
@@ -6,7 +6,7 @@ public class CollisionVertexInfo0c {
   public short x_00;
   public short z_02;
   public int _04;
-  public boolean _08;
+  public boolean _08; // Out-of-bounds edge
 
   public CollisionVertexInfo0c(final FileData data) {
     this.x_00 = data.readShort(0x00);

--- a/src/main/java/legend/game/submap/CollisionVertexInfo0c.java
+++ b/src/main/java/legend/game/submap/CollisionVertexInfo0c.java
@@ -6,12 +6,12 @@ public class CollisionVertexInfo0c {
   public short x_00;
   public short z_02;
   public int _04;
-  public boolean _08; // Out-of-bounds edge
+  public boolean boundary_08; // Used for out-of-bounds detection
 
   public CollisionVertexInfo0c(final FileData data) {
     this.x_00 = data.readShort(0x00);
     this.z_02 = data.readShort(0x02);
     this._04 = data.readInt(0x04);
-    this._08 = data.readInt(0x08) != 0;
+    this.boundary_08 = data.readInt(0x08) != 0;
   }
 }

--- a/src/main/java/legend/game/submap/CollisionVertexInfo0c.java
+++ b/src/main/java/legend/game/submap/CollisionVertexInfo0c.java
@@ -6,7 +6,8 @@ public class CollisionVertexInfo0c {
   public short x_00;
   public short z_02;
   public int _04;
-  public boolean boundary_08; // Used for out-of-bounds detection
+  /** Used for out-of-bounds detection */
+  public boolean boundary_08;
 
   public CollisionVertexInfo0c(final FileData data) {
     this.x_00 = data.readShort(0x00);

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -1035,7 +1035,7 @@ public class SMap extends EngineState {
       GTE.setTransforms(worldToScreenMatrix_800c3548);
       this.transformToWorldspace(worldspaceDeltaMovement, deltaMovement);
 
-      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.handlePlayerOrNpcMovementAndCollision(player.sobjIndex_12e != 0, playerModel.coord2_14.coord.transfer, worldspaceDeltaMovement);
+      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.checkCollision(player.sobjIndex_12e != 0, playerModel.coord2_14.coord.transfer, worldspaceDeltaMovement);
       if(collidedPrimitiveIndex >= 0) {
         if(this.isWalkable(collidedPrimitiveIndex)) {
           player.finishInterpolatedMovement();
@@ -1256,7 +1256,7 @@ public class SMap extends EngineState {
       GTE.setTransforms(worldToScreenMatrix_800c3548);
       this.transformToWorldspace(movement, deltaMovement);
 
-      this.collisionGeometry_800cbe08.handlePlayerOrNpcMovementAndCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
+      this.collisionGeometry_800cbe08.checkCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
 
       //LAB_800def08
       angle = MathHelper.positiveAtan2(movement.z, movement.x);
@@ -2954,7 +2954,7 @@ public class SMap extends EngineState {
       }
 
       //LAB_800e2140
-      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.handlePlayerOrNpcMovementAndCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
+      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.checkCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
       if(collidedPrimitiveIndex >= 0 && this.isWalkable(collidedPrimitiveIndex)) {
         model.coord2_14.coord.transfer.x += movement.x / (2.0f / vsyncMode_8007a3b8);
         model.coord2_14.coord.transfer.y = movement.y;

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -2577,8 +2577,8 @@ public class SMap extends EngineState {
         model.coord2_14.transforms.rotate.add(sobj.rotationAmount_17c);
       }
 
-      if(sobj.sobjIndex_12e == 0 && this.collisionGeometry_800cbe08.dartRotationWasUpdated_800d1a8c > 0) {
-        model.coord2_14.transforms.rotate.y = this.smoothDartRotation();
+      if(sobj.sobjIndex_12e == 0 && this.collisionGeometry_800cbe08.playerRotationWasUpdated_800d1a8c > 0) {
+        model.coord2_14.transforms.rotate.y = this.smoothPlayerRotation();
       }
 
       applyModelRotationAndScale(model);
@@ -4292,13 +4292,13 @@ public class SMap extends EngineState {
   }
 
   @Method(0x800ea4c8L)
-  private float smoothDartRotation() {
+  private float smoothPlayerRotation() {
     if(this.firstMovement) {
       this.firstMovement = false;
-      this.oldRotation_800f7f6c = this.collisionGeometry_800cbe08.dartRotationAfterCollision_800d1a84;
+      this.oldRotation_800f7f6c = this.collisionGeometry_800cbe08.playerRotationAfterCollision_800d1a84;
     }
 
-    float rotationDelta = (this.oldRotation_800f7f6c - this.collisionGeometry_800cbe08.dartRotationAfterCollision_800d1a84) % MathHelper.TWO_PI;
+    float rotationDelta = (this.oldRotation_800f7f6c - this.collisionGeometry_800cbe08.playerRotationAfterCollision_800d1a84) % MathHelper.TWO_PI;
 
     final boolean positive;
     if(Math.abs(rotationDelta) > MathHelper.PI) {
@@ -4312,7 +4312,7 @@ public class SMap extends EngineState {
 
     //LAB_800ea63c
     float maxRotation = MathHelper.PI / (6.0f * this.tickMultiplier());
-    if(this.collisionGeometry_800cbe08.dartRunning) {
+    if(this.collisionGeometry_800cbe08.playerRunning) {
       maxRotation *= 1.5f;
     }
 

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -3136,8 +3136,9 @@ public class SMap extends EngineState {
 
         //LAB_800e44d0
         //LAB_800e44e0
-        if(size * size >= dx * dx + dz * dz && (colliderMaxY >= collideeMinY && colliderMinY <= collideeMinY || colliderMaxY >= collideeMaxY && colliderMinY <= collideeMaxY) && sobj.collidedWithSobjIndex_19c == -1) {
+        if(size * size >= dx * dx + dz * dz && (colliderMaxY >= collideeMinY && colliderMinY <= collideeMinY || colliderMaxY >= collideeMaxY && colliderMinY <= collideeMaxY)) {
           sobj.collidedWithSobjIndex_19c = i;
+          return;
         }
       }
     }
@@ -3172,8 +3173,9 @@ public class SMap extends EngineState {
 
         //LAB_800e46bc
         //LAB_800e46cc
-        if(size * size >= dx * dx + dz * dz && (collideeMinY >= colliderMinY && collideeMinY <= colliderMaxY || collideeMaxY >= colliderMinY && collideeMaxY <= colliderMaxY) && sobj.collidedWithSobjIndex_1a8 == -1) {
+        if(size * size >= dx * dx + dz * dz && (collideeMinY >= colliderMinY && collideeMinY <= colliderMaxY || collideeMaxY >= colliderMinY && collideeMaxY <= colliderMaxY)) {
           sobj.collidedWithSobjIndex_1a8 = i;
+          return;
         }
       }
 

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -1035,7 +1035,7 @@ public class SMap extends EngineState {
       GTE.setTransforms(worldToScreenMatrix_800c3548);
       this.transformToWorldspace(worldspaceDeltaMovement, deltaMovement);
 
-      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.handleCollisionAndMovement(player.sobjIndex_12e != 0, playerModel.coord2_14.coord.transfer, worldspaceDeltaMovement);
+      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.handlePlayerOrNpcMovementAndCollision(player.sobjIndex_12e != 0, playerModel.coord2_14.coord.transfer, worldspaceDeltaMovement);
       if(collidedPrimitiveIndex >= 0) {
         if(this.isWalkable(collidedPrimitiveIndex)) {
           player.finishInterpolatedMovement();
@@ -1256,7 +1256,7 @@ public class SMap extends EngineState {
       GTE.setTransforms(worldToScreenMatrix_800c3548);
       this.transformToWorldspace(movement, deltaMovement);
 
-      this.collisionGeometry_800cbe08.handleCollisionAndMovement(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
+      this.collisionGeometry_800cbe08.handlePlayerOrNpcMovementAndCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
 
       //LAB_800def08
       angle = MathHelper.positiveAtan2(movement.z, movement.x);
@@ -2954,7 +2954,7 @@ public class SMap extends EngineState {
       }
 
       //LAB_800e2140
-      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.handleCollisionAndMovement(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
+      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.handlePlayerOrNpcMovementAndCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement);
       if(collidedPrimitiveIndex >= 0 && this.isWalkable(collidedPrimitiveIndex)) {
         model.coord2_14.coord.transfer.x += movement.x / (2.0f / vsyncMode_8007a3b8);
         model.coord2_14.coord.transfer.y = movement.y;


### PR DESCRIPTION
Decent improvement to understanding player/geometry collision. Inline commentary added to describe the purpose of a few `if` statements in `CollisionGeometry::handleCollision`.

### `CollisionVertexInfo0c`
* `x_00` and `z_02` are some sort of vector data
* `_04` is something like the inverse dot product* of the ordered pair and the two above values: `-1 * (x * x_00 + z * z_02)`
* `_08` renamed `boundary_08` indicates an edge against out-of-bounds territory (true = no adjacent collision primitive)

*Last one seems to always have a different value. Some sort of remainder value with a separate purpose? Possible it appears in more than just the last one, but haven't yet dug deep enough to say with confidence.