### PR TITLE
Patch update variety hour

### DIFF
--- a/patches/libs/widescreen.full.txt
+++ b/patches/libs/widescreen.full.txt
@@ -74,6 +74,8 @@ WS_SPEED:
 data 0
 WS_FRAMES:
 data 0
+WS_COLLIDED:
+data 0
 
 ; Rotate self to face provided coordinates.
 ; @param int WS_TARGET_X - target x
@@ -115,7 +117,7 @@ return
 ; @param int WS_TARGET_Y - target y
 ; @param int WS_TARGET_Z - target z
 ; @param int WS_ANIMATION_0 - animation index (use -1 to return; use -2 to wait)
-; @param int WS_SPEED - movement speed
+; @param int WS_SPEED - movement speed (use negative values for very slow movement)
 ; @return int WS_FRAMES - remaining frames/movement ticks
 WS_MOVE:
 call SMap::scriptReadModelPosition, stor[0], inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z]
@@ -128,6 +130,33 @@ call SMap::scriptSelfToggleAnimationDisabled, 0
 call SMap::scriptSelfLoadSobjAnimation, inl[:WS_ANIMATION_0]
 WS_MOVE_WAIT:
 wait inl[:WS_FRAMES]
+return
+
+; Move self to provided coordinates. Includes collision detection for other sObjs. Meant for regular NPC movement.
+; @param int WS_TARGET_X - target x
+; @param int WS_TARGET_Y - target y
+; @param int WS_TARGET_Z - target z
+; @param int WS_ANIMATION_0 - animation index
+; @param int WS_SPEED - movement speed (use negative values for very slow movement)
+; @return int WS_FRAMES - remaining frames/movement ticks
+WS_NPC_MOVE:
+call SMap::scriptReadModelPosition, stor[0], inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z]
+call SMap::scriptSelfMoveToPosition, inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z], 1
+call SMap::scriptSelfLoadSobjAnimation, 0
+yield
+call SMap::scriptGetSobjCollidedWith2, stor[0], inl[:WS_COLLIDED]
+jmp_cmp !=, inl[:WS_COLLIDED], 0xffffffff, inl[:WS_NPC_MOVE]
+gosub inl[:WS_GET_MOVE_TICKS]
+jmp_cmp <, inl[:WS_FRAMES], 0, inl[:RETURN]
+call SMap::scriptSelfMoveToPosition, inl[:WS_TARGET_X], inl[:WS_TARGET_Y], inl[:WS_TARGET_Z], inl[:WS_FRAMES]
+call SMap::scriptSelfLoadSobjAnimation, inl[:WS_ANIMATION_0]
+jmp_cmp ==, 0x0, inl[:WS_FRAMES], inl[:RETURN]
+WS_NPC_MOVE_0:
+yield
+call SMap::scriptGetSobjCollidedWith2, stor[0], inl[:WS_COLLIDED]
+jmp_cmp !=, inl[:WS_COLLIDED], 0xffffffff, inl[:WS_NPC_MOVE]
+while inl[:WS_FRAMES], inl[:WS_NPC_MOVE_0]
+call SMap::scriptSelfLoadSobjAnimation, 0
 return
 
 ; Calculate movement ticks between two points.
@@ -152,6 +181,15 @@ mul inl[:WS_MOVE_Z], inl[:WS_MOVE_Z]
 add inl[:WS_MOVE_X], inl[:WS_MOVE_Y]
 add inl[:WS_MOVE_Y], inl[:WS_MOVE_Z]
 sqrt inl[:WS_MOVE_Z], inl[:WS_FRAMES]
+jmp_cmp ==, inl[:WS_SPEED], 0, inl[:WS_INVALID_SPEED]
+jmp_cmp >, inl[:WS_SPEED], 0, inl[:WS_NORMAL_SPEED]
+WS_SLOW_SPEED:
+abs inl[:WS_SPEED]
+mul inl[:WS_SPEED], inl[:WS_FRAMES]
+return
+WS_INVALID_SPEED:
+mov 1, inl[:WS_SPEED]
+WS_NORMAL_SPEED:
 div inl[:WS_SPEED], inl[:WS_FRAMES]
 return
 

--- a/patches/libs/widescreen.txt
+++ b/patches/libs/widescreen.txt
@@ -32,7 +32,7 @@ WS_WAIT_FLAG_SOBJ:
 data 0xffffffff
 ; Wait for flag to match a given value. Face sobj while waiting if provided.
 ; @param int WS_WAIT_FLAG - flags 1 bit
-; @param int WS_WAIT_FLAG_VALUE - match value
+; @param int WS_WAIT_FLAG_MATCH - match value
 ; @param int WS_WAIT_FLAG_SOBJ - sobj index
 WS_FLAG_WAIT:
 call 3, inl[:WS_WAIT_FLAG], inl[:WS_WAIT_FLAG_STATUS]
@@ -69,6 +69,8 @@ data 0
 WS_SPEED:
 data 0
 WS_FRAMES:
+data 0
+WS_COLLIDED:
 data 0
 ; Rotate self to face provided coordinates.
 ; @param int WS_TARGET_X - target x
@@ -109,7 +111,7 @@ return
 ; @param int WS_TARGET_Y - target y
 ; @param int WS_TARGET_Z - target z
 ; @param int WS_ANIMATION_0 - animation index (use -1 to return; use -2 to wait)
-; @param int WS_SPEED - movement speed
+; @param int WS_SPEED - movement speed (use negative values for very slow movement)
 ; @return int WS_FRAMES - remaining frames/movement ticks
 WS_MOVE:
 call 102, stor[0], inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z]
@@ -122,6 +124,32 @@ call 99, 0
 call 97, inl[:WS_ANIMATION_0]
 WS_MOVE_WAIT:
 wait inl[:WS_FRAMES]
+return
+; Move self to provided coordinates. Includes collision detection for other sObjs. Meant for regular NPC movement.
+; @param int WS_TARGET_X - target x
+; @param int WS_TARGET_Y - target y
+; @param int WS_TARGET_Z - target z
+; @param int WS_ANIMATION_0 - animation index
+; @param int WS_SPEED - movement speed (use negative values for very slow movement)
+; @return int WS_FRAMES - remaining frames/movement ticks
+WS_NPC_MOVE:
+call 102, stor[0], inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z]
+call 107, inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z], 1
+call 97, 0
+yield
+call 308, stor[0], inl[:WS_COLLIDED]
+jmp_cmp !=, inl[:WS_COLLIDED], 0xffffffff, inl[:WS_NPC_MOVE]
+gosub inl[:WS_GET_MOVE_TICKS]
+jmp_cmp <, inl[:WS_FRAMES], 0, inl[:RETURN]
+call 107, inl[:WS_TARGET_X], inl[:WS_TARGET_Y], inl[:WS_TARGET_Z], inl[:WS_FRAMES]
+call 97, inl[:WS_ANIMATION_0]
+jmp_cmp ==, 0x0, inl[:WS_FRAMES], inl[:RETURN]
+WS_NPC_MOVE_0:
+yield
+call 308, stor[0], inl[:WS_COLLIDED]
+jmp_cmp !=, inl[:WS_COLLIDED], 0xffffffff, inl[:WS_NPC_MOVE]
+while inl[:WS_FRAMES], inl[:WS_NPC_MOVE_0]
+call 97, 0
 return
 ; Calculate movement ticks between two points.
 ; @param int WS_START_X - pointA x
@@ -145,6 +173,15 @@ mul inl[:WS_MOVE_Z], inl[:WS_MOVE_Z]
 add inl[:WS_MOVE_X], inl[:WS_MOVE_Y]
 add inl[:WS_MOVE_Y], inl[:WS_MOVE_Z]
 sqrt inl[:WS_MOVE_Z], inl[:WS_FRAMES]
+jmp_cmp ==, inl[:WS_SPEED], 0, inl[:WS_INVALID_SPEED]
+jmp_cmp >, inl[:WS_SPEED], 0, inl[:WS_NORMAL_SPEED]
+WS_SLOW_SPEED:
+abs inl[:WS_SPEED]
+mul inl[:WS_SPEED], inl[:WS_FRAMES]
+return
+WS_INVALID_SPEED:
+mov 1, inl[:WS_SPEED]
+WS_NORMAL_SPEED:
 div inl[:WS_SPEED], inl[:WS_FRAMES]
 return
 ; Load one animation and wait until complete

--- a/patches/scripts/DRGN21/123/3.diff
+++ b/patches/scripts/DRGN21/123/3.diff
@@ -10,10 +10,10 @@ Shana
 # Move from behind tree instead of suddenly appearing on the path.
 +call 267, stor[24], inl[:WS_TARGET_X], inl[:WS_TARGET_Y], inl[:WS_TARGET_Z]
 +call 677, stor[0], inl[:WS_TARGET_X], inl[:WS_TARGET_Y], inl[:WS_TARGET_Z]
-+mov 20, inl[:WS_FRAMES]
-+wait inl[:WS_FRAMES]
 +mov 6, inl[:WS_SPEED]
 +mov 2, inl[:WS_ANIMATION_0]
++mov 20, inl[:WS_FRAMES]
++wait inl[:WS_FRAMES]
 +call 111, 1
 +gosub inl[:WS_MOVE]
 +call 111, 0

--- a/patches/scripts/DRGN21/249/5.diff
+++ b/patches/scripts/DRGN21/249/5.diff
@@ -1,93 +1,29 @@
-Adds movement animation to Lavitz's mother after the house tour ends.
-This positions her for Lavitz's hug in case the player starts the hug cutscene as soon as possible.
-Retail bug fix
+Bale, Lavitz's Home
+Lavitz's Mother
+Retail bug: Lavitz's hug script is hardcoded to expect his mother to be in her default position. Immediately after the
+house tour, she stands in a different position. This patch adds movement animation to reposition her after the cutscene.
 --- original
 +++ modified
-@@ -106,7 +106,83 @@
- yield
- call 1, stor[24]
- jmp_cmp !=, 0x0, stor[24], inl[:LABEL_16]
-# Rotate to target
-+call 102, stor[0], inl[:MOM_X], inl[:MOM_Y], inl[:MOM_Z]
-+mov 0x41, inl[:TARGET_X]
-+mov 0xffffffcd, inl[:TARGET_Y]
-+mov 0x5c, inl[:TARGET_Z]
-+gosub inl[:ROTATE_0]
-+COLLISION_CHECK:
-+call 102, stor[0], inl[:MOM_X], inl[:MOM_Y], inl[:MOM_Z]
-+call 107, inl[:MOM_X], inl[:MOM_Y], inl[:MOM_Z], 1
+@@ -169,7 +169,20 @@
+ mov 0x8, stor[25]
+ gosub inl[:LABEL_2]
+ gosub inl[:LABEL_16]
+# Rotate towards and move to default position
++mov 0x41, inl[:WS_TARGET_X]
++mov 0xffffffcd, inl[:WS_TARGET_Y]
++mov 0x5c, inl[:WS_TARGET_Z]
++mov 10, inl[:WS_FRAMES]
++mov 1, inl[:WS_ANIMATION_0]
++gosub inl[:WS_ROTATE]
++mov 2, inl[:WS_SPEED]
++gosub inl[:WS_NPC_MOVE]
+# Rotate to face player
++call 102, var[64][0], inl[:WS_TARGET_X], inl[:WS_TARGET_Y], inl[:WS_TARGET_Z]
++mov 10, inl[:WS_FRAMES]
++gosub inl[:WS_ROTATE]
 +call 97, 0
-+yield
-+call 308, stor[0], inl[:TARGET_Z]
-+jmp_cmp ==, 0, inl[:TARGET_Z], inl[:COLLISION_CHECK]
-# Calculate movement ticks
-+mov 0x41, inl[:TARGET_X]
-+mov 0xffffffcd, inl[:TARGET_Y]
-+mov 0x5c, inl[:TARGET_Z]
-+sub inl[:TARGET_X], inl[:MOM_X]
-+sub inl[:TARGET_Y], inl[:MOM_Y]
-+sub inl[:TARGET_Z], inl[:MOM_Z]
-+mul inl[:MOM_X], inl[:MOM_X]
-+mul inl[:MOM_Y], inl[:MOM_Y]
-+mul inl[:MOM_Z], inl[:MOM_Z]
-+add inl[:MOM_X], inl[:MOM_Y]
-+add inl[:MOM_Y], inl[:MOM_Z]
-+sqrt inl[:MOM_Z], inl[:MOM_Z]
-+abs inl[:MOM_Z]
-+jmp_cmp <=, 2, inl[:MOM_Z], inl[:CONTINUE]
-+mov 2, inl[:MOM_Z]
-+CONTINUE:
-+div 2, inl[:MOM_Z]
-# Move to target
-+call 107, inl[:TARGET_X], inl[:TARGET_Y], inl[:TARGET_Z], inl[:MOM_Z]
-+call 97, 1
-+gosub inl[:WALK]
-# Rotate to player
-+call 102, stor[0], inl[:MOM_X], inl[:MOM_Y], inl[:MOM_Z]
-+call 102, var[64][0], inl[:TARGET_X], inl[:TARGET_Y], inl[:TARGET_Z]
-+gosub inl[:ROTATE_0]
  return
-+ROTATE_0:
-+sub inl[:MOM_X], inl[:TARGET_X]
-+sub inl[:MOM_Z], inl[:TARGET_Z]
-+atan2_12 inl[:TARGET_X], inl[:TARGET_Z], inl[:TARGET_Y]
-+call 104, stor[0], inl[:TARGET_Z], inl[:TARGET_X], inl[:TARGET_Z]
-+and 0xfff, inl[:TARGET_X]
-+sub inl[:TARGET_X], inl[:TARGET_Y]
-+add 0x800, inl[:TARGET_Y]
-+360_NEG_BOUND:
-+jmp_cmp >=, inl[:TARGET_Y], 0xfffff800, inl[:360_POS_BOUND]
-+add 0x1000, inl[:TARGET_Y]
-+360_POS_BOUND:
-+jmp_cmp <, inl[:TARGET_Y], 0x800, inl[:ROTATE_1]
-+sub 0x1000, inl[:TARGET_Y]
-+ROTATE_1:
-+call 120, stor[0], 0, inl[:TARGET_Y], 0, 10
-+call 97, 1
-+wait 10
-+call 97, 0
-+return
-+WALK:
-+jmp_cmp ==, 0x0, inl[:MOM_Z], inl[:STOP]
-+yield
-+call 308, stor[0], inl[:TARGET_Z]
-+jmp_cmp ==, 0, inl[:TARGET_Z], inl[:COLLISION_CHECK]
-+while inl[:MOM_Z], inl[:WALK]
-+STOP:
-+call 97, 0
-+return
-+MOM_X:
-+data 0
-+MOM_Y:
-+data 0
-+MOM_Z:
-+data 0
-+TARGET_X:
-+data 0
-+TARGET_Y:
-+data 0
-+TARGET_Z:
-+data 0
- ENTRYPOINT_0:
- ENTRYPOINT_2:
- ENTRYPOINT_3:
++#include ../../../../patches/libs/widescreen.txt
+ LABEL_23:
+ call 106, 0x0
+ call 101, stor[0], 0xfffffffe, 0xffffffcd, 0x12a

--- a/patches/scripts/DRGN21/51/2.diff
+++ b/patches/scripts/DRGN21/51/2.diff
@@ -5,22 +5,16 @@ Old: Shana would stack on Dart and Lavitz
 New: Shana waits for Lavitz to move before continuing
 --- original
 +++ modified
-@@ -48,11 +48,13 @@
+@@ -48,6 +48,7 @@
  yield
  call 102, stor[0], stor[8], stor[9], stor[10]
  call 116, stor[24]
-# Inside walking loop for LABEL_2 subroutine
+# Inside walking loop for LABEL_2 subroutine, increment wait offset if specified flag is active
 +gosub inl[:WS_WAIT_TIME]
  jmp_cmp !=, 0x0, stor[24], inl[:LABEL_4]
  call 294, 0x0, 0x1
  call 97, 0x0
- call 111, 0x0
- return
-+#include ../../../../patches/libs/widescreen.txt
- LABEL_5:
- mov var[64][stor[28]], stor[28]
- call 102, stor[28], stor[29], stor[30], stor[31]
-@@ -149,15 +151,23 @@
+@@ -149,15 +150,23 @@
  mov 0x17, stor[24]
  gosub inl[:LABEL_2]
  mov 0x2e, stor[24]
@@ -46,3 +40,8 @@ New: Shana waits for Lavitz to move before continuing
  mov 0x18, stor[24]
  gosub inl[:LABEL_2]
  LABEL_12:
+@@ -264,3 +273,4 @@
+ yield
+ jmp inl[:LABEL_18]
+ data 0x49
++#include ../../../../patches/libs/widescreen.txt

--- a/patches/scripts/DRGN21/51/3.diff
+++ b/patches/scripts/DRGN21/51/3.diff
@@ -5,15 +5,7 @@ Old: Lavitz would stack on Dart and Shana
 New: Lavitz waits for Dart to move before continuing
 --- original
 +++ modified
-@@ -130,6 +130,7 @@
- rel :JMP_404_2
- rel :JMP_404_0
- rel :JMP_404_0
-+#include ../../../../patches/libs/widescreen.txt
- JMP_404_1:
- yield
- call 3, 0x78, stor[24]
-@@ -150,6 +151,8 @@
+@@ -150,6 +150,8 @@
  mov 0x2e, stor[24]
  gosub inl[:LABEL_2]
  mov 0xf, stor[24]
@@ -23,3 +15,8 @@ New: Lavitz waits for Dart to move before continuing
  gosub inl[:LABEL_2]
  LABEL_11:
  yield
+@@ -231,3 +233,4 @@
+ LABEL_18:
+ yield
+ jmp inl[:LABEL_18]
++#include ../../../../patches/libs/widescreen.txt

--- a/patches/scripts/DRGN21/51/9.diff
+++ b/patches/scripts/DRGN21/51/9.diff
@@ -3,22 +3,16 @@ Hellena Prison, cutscene before fighting Fruegel (I)
 Warden
 --- original
 +++ modified
-@@ -58,11 +58,13 @@
+@@ -58,6 +58,7 @@
  yield
  call 102, stor[0], stor[8], stor[9], stor[10]
  call 116, stor[24]
-# Inside walking loop for LABEL_4 subroutine
+# Inside walking loop for LABEL_4 subroutine, increment wait offset if specified flag is active
 +gosub inl[:WS_WAIT_TIME]
  jmp_cmp !=, 0x0, stor[24], inl[:LABEL_6]
  call 294, 0x0, 0x1
  call 97, 0x0
- call 111, 0x0
- return
-+#include ../../../../patches/libs/widescreen.txt
- LABEL_7:
- mov var[64][stor[28]], stor[28]
- call 102, stor[28], stor[29], stor[30], stor[31]
-@@ -176,18 +178,48 @@
+@@ -176,18 +177,48 @@
  rel :JMP_630_0
  rel :JMP_630_0
  JMP_630_1:
@@ -36,8 +30,8 @@ Warden
 +mov 0, inl[:WS_WAIT_FLAG_MATCH]
 +gosub inl[:WS_FLAG_WAIT]
 +call 2, 0x78, 1
-+call 96, 0x4
-+call 106, 0x0
++call 96, 4
++call 106, 0
 +mov 0x7a, inl[:WS_WAIT_FLAG]
 +mov 0, inl[:WS_WAIT_OFFSET]
 +mov 0x28, stor[24]
@@ -75,3 +69,8 @@ Warden
  mov 0x18, stor[24]
  gosub inl[:LABEL_4]
  mov 0x1, stor[25]
+@@ -295,3 +326,4 @@
+ yield
+ jmp inl[:LABEL_24]
+ data 0x49
++#include ../../../../patches/libs/widescreen.txt

--- a/patches/scripts/DRGN21/96/3.diff
+++ b/patches/scripts/DRGN21/96/3.diff
@@ -1,16 +1,17 @@
-Retail checks to see if the sobj is already at the target location, but the code for handling that situation is inadequate.
-Retail math precision issues means the sobj never reaches its destination exactly, so retail always bypasses these checks.
+Hellena Prison (II), Jiango Pit
+Lavitz
+Retail: Checks if Lavitz is already at the target location. Poor math precision means he never arrives to the exact
+location, so it never exits the subroutine early.
+SC: High precision meets early exit conditions. Early exit doesn't reset to an idle animation or guarantee
+the wait timer's stor is positive, so he walks in place, sometimes indefinitely.
+Fix: Bypass unnecessary early exit.
 --- original
 +++ modified
-@@ -157,11 +157,6 @@
+@@ -157,6 +157,7 @@
  call 97, 0x2
  LABEL_25:
  call 102, stor[0], stor[29], stor[30], stor[31]
--jmp_cmp !=, stor[29], stor[24], inl[:LABEL_26]
--jmp_cmp !=, stor[30], stor[25], inl[:LABEL_26]
--jmp_cmp !=, stor[31], stor[26], inl[:LABEL_26]
--jmp inl[:LABEL_31]
--LABEL_26:
- sub stor[24], stor[29]
- sub stor[25], stor[30]
- sub stor[26], stor[31]
++jmp inl[:LABEL_26]
+ jmp_cmp !=, stor[29], stor[24], inl[:LABEL_26]
+ jmp_cmp !=, stor[30], stor[25], inl[:LABEL_26]
+ jmp_cmp !=, stor[31], stor[26], inl[:LABEL_26]

--- a/patches/scripts/DRGN22/1137/7.diff
+++ b/patches/scripts/DRGN22/1137/7.diff
@@ -6,7 +6,7 @@ New: No more hiding, added animation
 --- original
 +++ modified
 ## FIRST SCENE ##
-@@ -153,6 +153,15 @@
+@@ -153,6 +153,17 @@
  call 99, 0x0
  call 97, 0x0
  LABEL_23:
@@ -27,7 +27,7 @@ New: No more hiding, added animation
  call 257, stor[24], stor[25]
  jmp_cmp <, 0xfffffff1, stor[24], inl[:LABEL_23]
 ## SECOND SCENE ##
-@@ -165,20 +174,21 @@
+@@ -165,20 +176,21 @@
  call 99, 0x0
  call 97, 0xb
  call 99, 0x1

--- a/patches/scripts/DRGN22/1137/8.diff
+++ b/patches/scripts/DRGN22/1137/8.diff
@@ -10,7 +10,7 @@ New: Libria animation handled by File 8, now on screen with Lisa
  JMP_44_0:
  call 101, stor[0], 0x82, 0x32, 0xcd
  call 103, stor[0], 0x0, 0x0, 0x0
-+call 106, 0x1
++call 106, 1
 +gosub inl[:SC_LIBRIA_SCENE_0]
 +rewind
  call 127, stor[31]
@@ -32,9 +32,9 @@ New: Libria animation handled by File 8, now on screen with Lisa
 # Disable shadow, unhide, and set position/rotation
 +call 312, stor[0]
 +call 106, 0
-+call 101, stor[0], 0xac, inl[:S0_START_Y], 0xaa
++call 101, stor[0], 0xac, inl[:SCENE_0_START_Y], 0xaa
 +mov 0x7d, inl[:WS_TARGET_X]
-+mov inl[:S0_START_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_0_START_Y], inl[:WS_TARGET_Y]
 +mov 0xdc, inl[:WS_TARGET_Z]
 +mov 1, inl[:WS_ANIMATION_0]
 +mov 2, inl[:WS_SPEED]
@@ -54,33 +54,33 @@ New: Libria animation handled by File 8, now on screen with Lisa
 +gosub inl[:WS_FLAG_WAIT]
 +mov 0xffffffff, inl[:WS_WAIT_FLAG_SOBJ]
 # Compare distance with Libria's retail start and wait
-+mov inl[:S0_MARK_X], inl[:WS_TARGET_X]
-+mov inl[:S0_MARK_Y], inl[:WS_TARGET_Y]
-+mov inl[:S0_MARK_Z], inl[:WS_TARGET_Z]
-+mov inl[:S0_START_X], inl[:WS_START_X]
-+mov inl[:S0_START_Y], inl[:WS_START_Y]
-+mov inl[:S0_START_Z], inl[:WS_START_Z]
++mov inl[:SCENE_0_MARK_X], inl[:WS_TARGET_X]
++mov inl[:SCENE_0_MARK_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_0_MARK_Z], inl[:WS_TARGET_Z]
++mov inl[:SCENE_0_START_X], inl[:WS_START_X]
++mov inl[:SCENE_0_START_Y], inl[:WS_START_Y]
++mov inl[:SCENE_0_START_Z], inl[:WS_START_Z]
 +mov 2, inl[:WS_SPEED]
 +gosub inl[:WS_GET_MOVE_TICKS]
 +mov inl[:WS_FRAMES], stor[22]
 +call 102, stor[0], inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z]
 +gosub inl[:WS_GET_MOVE_TICKS]
 +mov inl[:WS_FRAMES], stor[23]
-+jmp_cmp >, stor[23], stor[22], inl[:S0_NO_WAIT]
++jmp_cmp >, stor[23], stor[22], inl[:SCENE_0_NO_WAIT]
 +sub stor[23], stor[22]
 +wait stor[22]
-+S0_NO_WAIT:
++SCENE_0_NO_WAIT:
 # Rotate and move to greet party
-+mov inl[:S0_MARK_X], inl[:WS_TARGET_X]
-+mov inl[:S0_MARK_Z], inl[:WS_TARGET_Z]
++mov inl[:SCENE_0_MARK_X], inl[:WS_TARGET_X]
++mov inl[:SCENE_0_MARK_Z], inl[:WS_TARGET_Z]
 +mov 0xffffffff, inl[:WS_ANIMATION_0]
 +mov 16, inl[:WS_FRAMES]
 +gosub inl[:WS_ROTATE]
 +mov 10, inl[:WS_FRAMES]
 +wait inl[:WS_FRAMES]
-+mov inl[:S0_MARK_X], inl[:WS_TARGET_X]
-+mov inl[:S0_MARK_Y], inl[:WS_TARGET_Y]
-+mov inl[:S0_MARK_Z], inl[:WS_TARGET_Z]
++mov inl[:SCENE_0_MARK_X], inl[:WS_TARGET_X]
++mov inl[:SCENE_0_MARK_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_0_MARK_Z], inl[:WS_TARGET_Z]
 +mov 1, inl[:WS_ANIMATION_0]
 +mov 2, inl[:WS_SPEED]
 +gosub inl[:WS_MOVE]
@@ -100,7 +100,7 @@ New: Libria animation handled by File 8, now on screen with Lisa
 +gosub inl[:WS_FLAG_WAIT]
 # Exit
 +mov 0xac, inl[:WS_TARGET_X]
-+mov inl[:S0_START_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_0_START_Y], inl[:WS_TARGET_Y]
 +mov 0xab, inl[:WS_TARGET_Z]
 +mov 0xffffffff, inl[:WS_ANIMATION_0]
 +mov 16, inl[:WS_FRAMES]
@@ -112,17 +112,17 @@ New: Libria animation handled by File 8, now on screen with Lisa
 +gosub inl[:WS_MOVE]
 +rewind
 # First scene retail coords
-+S0_START_X:
++SCENE_0_START_X:
 +data 0x87
-+S0_START_Y:
++SCENE_0_START_Y:
 +data 0xfffffff6
-+S0_START_Z:
++SCENE_0_START_Z:
 +data 0x9b
-+S0_MARK_X:
++SCENE_0_MARK_X:
 +data 0x44
-+S0_MARK_Y:
++SCENE_0_MARK_Y:
 +data 0xfffffff6
-+S0_MARK_Z:
++SCENE_0_MARK_Z:
 +data 0xdc
 ## SECOND SCENE ##
 +SC_LIBRIA_SCENE_1:
@@ -133,9 +133,9 @@ New: Libria animation handled by File 8, now on screen with Lisa
 # Disable shadow, unhide, and set position/rotation
 +call 312, stor[0]
 +call 106, 0
-+call 101, stor[0], 0xac, inl[:S1_START_Y], 0xaa
++call 101, stor[0], 0xac, inl[:SCENE_1_START_Y], 0xaa
 +mov 0x7d, inl[:WS_TARGET_X]
-+mov inl[:S1_START_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_1_START_Y], inl[:WS_TARGET_Y]
 +mov 0xfa, inl[:WS_TARGET_Z]
 +mov 1, inl[:WS_ANIMATION_0]
 +mov 2, inl[:WS_SPEED]
@@ -154,33 +154,33 @@ New: Libria animation handled by File 8, now on screen with Lisa
 +gosub inl[:WS_FLAG_WAIT]
 +mov 0xffffffff, inl[:WS_WAIT_FLAG_SOBJ]
 # Compare distance with Libria's retail start and wait
-+mov inl[:S1_MARK_X], inl[:WS_TARGET_X]
-+mov inl[:S1_MARK_Y], inl[:WS_TARGET_Y]
-+mov inl[:S1_MARK_Z], inl[:WS_TARGET_Z]
-+mov inl[:S1_START_X], inl[:WS_START_X]
-+mov inl[:S1_START_Y], inl[:WS_START_Y]
-+mov inl[:S1_START_Z], inl[:WS_START_Z]
++mov inl[:SCENE_1_MARK_X], inl[:WS_TARGET_X]
++mov inl[:SCENE_1_MARK_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_1_MARK_Z], inl[:WS_TARGET_Z]
++mov inl[:SCENE_1_START_X], inl[:WS_START_X]
++mov inl[:SCENE_1_START_Y], inl[:WS_START_Y]
++mov inl[:SCENE_1_START_Z], inl[:WS_START_Z]
 +mov 2, inl[:WS_SPEED]
 +gosub inl[:WS_GET_MOVE_TICKS]
 +mov inl[:WS_FRAMES], stor[22]
 +call 102, stor[0], inl[:WS_START_X], inl[:WS_START_Y], inl[:WS_START_Z]
 +gosub inl[:WS_GET_MOVE_TICKS]
 +mov inl[:WS_FRAMES], stor[23]
-+jmp_cmp >, stor[23], stor[22], inl[:S1_NO_WAIT]
++jmp_cmp >, stor[23], stor[22], inl[:SCENE_1_NO_WAIT]
 +sub stor[23], stor[22]
 +wait stor[22]
-+S1_NO_WAIT:
++SCENE_1_NO_WAIT:
 # Rotate and move to greet party
-+mov inl[:S1_MARK_X], inl[:WS_TARGET_X]
-+mov inl[:S1_MARK_Z], inl[:WS_TARGET_Z]
++mov inl[:SCENE_1_MARK_X], inl[:WS_TARGET_X]
++mov inl[:SCENE_1_MARK_Z], inl[:WS_TARGET_Z]
 +mov 0xffffffff, inl[:WS_ANIMATION_0]
 +mov 16, inl[:WS_FRAMES]
 +gosub inl[:WS_ROTATE]
 +mov 10, inl[:WS_FRAMES]
 +wait inl[:WS_FRAMES]
-+mov inl[:S1_MARK_X], inl[:WS_TARGET_X]
-+mov inl[:S1_MARK_Y], inl[:WS_TARGET_Y]
-+mov inl[:S1_MARK_Z], inl[:WS_TARGET_Z]
++mov inl[:SCENE_1_MARK_X], inl[:WS_TARGET_X]
++mov inl[:SCENE_1_MARK_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_1_MARK_Z], inl[:WS_TARGET_Z]
 +mov 1, inl[:WS_ANIMATION_0]
 +mov 2, inl[:WS_SPEED]
 +gosub inl[:WS_MOVE]
@@ -200,7 +200,7 @@ New: Libria animation handled by File 8, now on screen with Lisa
 +gosub inl[:WS_FLAG_WAIT]
 # Exit
 +mov 0xac, inl[:WS_TARGET_X]
-+mov inl[:S1_START_Y], inl[:WS_TARGET_Y]
++mov inl[:SCENE_1_START_Y], inl[:WS_TARGET_Y]
 +mov 0xab, inl[:WS_TARGET_Z]
 +mov 0xffffffff, inl[:WS_ANIMATION_0]
 +mov 16, inl[:WS_FRAMES]
@@ -212,16 +212,16 @@ New: Libria animation handled by File 8, now on screen with Lisa
 +gosub inl[:WS_MOVE]
 +return
 # Second scene retail coords
-+S1_START_X:
++SCENE_1_START_X:
 +data 0x86
-+S1_START_Y:
++SCENE_1_START_Y:
 +data 0xfffffff6
-+S1_START_Z:
++SCENE_1_START_Z:
 +data 0xc0
-+S1_MARK_X:
++SCENE_1_MARK_X:
 +data 0x47
-+S1_MARK_Y:
++SCENE_1_MARK_Y:
 +data 0xfffffff6
-+S1_MARK_Z:
++SCENE_1_MARK_Z:
 +data 0xe1
 +#include ../../../../patches/libs/widescreen.txt

--- a/patches/scripts/DRGN24/612/3.diff
+++ b/patches/scripts/DRGN24/612/3.diff
@@ -1,16 +1,17 @@
-Retail checks to see if the sobj is already at the target location, but the code for handling that situation is inadequate.
-Retail math precision issues means the sobj never reaches its destination exactly, so retail always bypasses these checks.
+Aglis, Entrance
+Meru
+Retail: Checks if Meru is already at the target location. Poor math precision means he never arrives to the exact
+location, so it never exits the subroutine early.
+Severed Chains: High precision meets early exit conditions. Early exit doesn't reset to an idle animation so she
+sometimes runs in place.
+Fix: Bypass unnecessary early exit.
 --- original
 +++ modified
-@@ -149,11 +149,6 @@
+@@ -149,6 +149,7 @@
  call 97, 0x2
  LABEL_23:
  call 102, stor[0], stor[29], stor[30], stor[31]
--jmp_cmp !=, stor[29], stor[24], inl[:LABEL_24]
--jmp_cmp !=, stor[30], stor[25], inl[:LABEL_24]
--jmp_cmp !=, stor[31], stor[26], inl[:LABEL_24]
--jmp inl[:LABEL_29]
--LABEL_24:
- sub stor[24], stor[29]
- sub stor[25], stor[30]
- sub stor[26], stor[31]
++jmp inl[:LABEL_24]
+ jmp_cmp !=, stor[29], stor[24], inl[:LABEL_24]
+ jmp_cmp !=, stor[30], stor[25], inl[:LABEL_24]
+ jmp_cmp !=, stor[31], stor[26], inl[:LABEL_24]


### PR DESCRIPTION
Updated "widescreen" library for movement with collision waiting.
Updated patch for Lavitz's mom to use new subroutine `DRGN21/249/5.diff`

Fixed bad line metadata on Rose patch `DRGN22/1137/7.diff`
Revised pointer names for Libria patch `DRGN22/1137/8.diff`

Revised patches and commentary for running in place Lavitz `DRGN21/96/3.diff` and Meru `DRGN24/612/3.diff`

Patches with minor updates*:
* Prairie
`DRGN21/123/3.diff`
* Helena Prison - Before first Fruegel fight
`DRGN21/51/2.diff`
`DRGN21/51/3.diff`
`DRGN21/51/9.diff`

*These patches are going to get reapplied due to the library update anyway, so might as well get some improvements and updated commentary in at the same time. Improvements are almost entirely to localizing changes.