### PR TITLE
Fix wrong battle stage being selected

### DIFF
--- a/src/main/java/legend/game/debugger/DebuggerController.java
+++ b/src/main/java/legend/game/debugger/DebuggerController.java
@@ -307,7 +307,7 @@ public class DebuggerController {
   @FXML
   private void startEncounter(final ActionEvent event) {
     if(currentEngineState_8004dd04 instanceof final SMap smap) {
-      smap.submap.prepareEncounter(this.encounterId.getValue());
+      smap.submap.prepareEncounter(this.encounterId.getValue(), false);
       smap.mapTransition(-1, 0);
     } else if(currentEngineState_8004dd04 instanceof final WMap wmap) {
       encounterId_800bb0f8 = this.encounterId.getValue();

--- a/src/main/java/legend/game/submap/RetailSubmap.java
+++ b/src/main/java/legend/game/submap/RetailSubmap.java
@@ -409,10 +409,10 @@ public class RetailSubmap extends Submap {
   }
 
   @Override
-  public void prepareEncounter(final int encounterId) {
+  public void prepareEncounter(final int encounterId, final boolean useBattleStage) {
     final var sceneId = encounterData_800f64c4[this.cut].scene_00;
     final var scene = sceneEncounterIds_800f74c4[sceneId];
-    final var battleStageId = encounterData_800f64c4[this.cut].stage_03 == 0 && battleStage_800bb0f4 > -1 ? battleStage_800bb0f4 : encounterData_800f64c4[this.cut].stage_03;
+    final var battleStageId = useBattleStage ? battleStage_800bb0f4 : encounterData_800f64c4[this.cut].stage_03;
 
     final var generateEncounterEvent = EVENTS.postEvent(new SubmapGenerateEncounterEvent(encounterId, battleStageId, this.cut, sceneId, scene));
     encounterId_800bb0f8 = generateEncounterEvent.encounterId;
@@ -424,11 +424,11 @@ public class RetailSubmap extends Submap {
   }
 
   @Override
-  public void prepareEncounter() {
+  public void prepareEncounter(final boolean useBattleStage) {
     final var sceneId = encounterData_800f64c4[this.cut].scene_00;
     final var scene = sceneEncounterIds_800f74c4[sceneId];
     final var encounterId = scene[this.randomEncounterIndex()];
-    this.prepareEncounter(encounterId);
+    this.prepareEncounter(encounterId, useBattleStage);
   }
 
   @Override

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -766,7 +766,7 @@ public class SMap extends EngineState {
       case CHECK_TRANSITIONS_1_2:
         if((this.submapFlags_800f7e54 & 0x1) == 0) {
           if(this.canEncounter()) {
-            this.submap.prepareEncounter();
+            this.submap.prepareEncounter(false);
             this.mapTransition(-1, 0);
           }
         }
@@ -3978,7 +3978,7 @@ public class SMap extends EngineState {
     final int scene = script.params_20[1].get();
 
     if(script.params_20[0].get() == -1) {
-      this.submap.prepareEncounter(scene);
+      this.submap.prepareEncounter(scene, true);
     }
 
     this.mapTransition(script.params_20[0].get(), scene);

--- a/src/main/java/legend/game/submap/Submap.java
+++ b/src/main/java/legend/game/submap/Submap.java
@@ -35,8 +35,8 @@ public abstract class Submap {
   public abstract void calcGoodScreenOffset(final float x, final float y, final Vector2f out);
 
   public abstract int getEncounterRate();
-  public abstract void prepareEncounter();
-  public abstract void prepareEncounter(final int encounterId);
+  public abstract void prepareEncounter(final boolean useBattleStage);
+  public abstract void prepareEncounter(final int encounterId, final boolean useBattleStage);
 
   public boolean hasEncounters() {
     return this.getEncounterRate() != 0;


### PR DESCRIPTION
### Problem

- Forced encounters (from cutscene) usually leave their encounterData entry blank (0,0,0)
- A few of these forced encounters do not leave them blank
- New logic expected that if the entry for encounterData.stage_03 was == 0 that we defer to the battleStage_800bb0f4
- Thus, a few of the bosses encounterData was set when they shouldn't have been
- The original implementation had an override in one of the code paths to ignore encounterData completely
  - This wasn't respected enough in the new implementation
- We can't set the encounterData entries to 0,0,0 as some bosses (kamuy) use the same cut / scene / encounterData for walkable encounters as well (snake does not do this)
  - Which is how you can get walkable encounters on a submap with a forced encounter _I guess is how they decided to do it_

### Solutions

**Proper Solution - Refactor all encounterData to be consistent** ❌ 
- Give each encounterData entry its full information, no more blank entries (0,0,0)
- _Somehow_ separate random walkable encounter submap.cuts from using the same cut for forced encounters on the submap
- Remove all the prior logic, ignore the battleStage_800bb0f4 (set by scripts / submaps) completely
- Manually identify which ones overlap w/ boss encounters and correct/expand those
  - Can only confirm by in-game or automating a logging process from the game
  - Or Zy has a table for this somewhere

The difficulty here is that the encounterIds do not match the submap.cuts. We can use `cutToSubmap_800d610c` to map cut to submap and then get the scene . However, looking at how the `cut` is used, I'm not sure `cutToSubmap_800d610c` is fully respected by submap scripts? Maybe it is. 🤷

Then the manual data entry work of identifying where boss encounters overlap with regular encounters.

**Retail Accurate - Add a flag to represent the code paths** ✅ 
- Code flows tell us what to do (structured programming btw)
- Capture that in a flag and pass it around
- Just Works™️ 

### Testing

- Kamuy
  - Was broken as expected
  - Boss encounter loads correct battlestage
  - Random walkable encounters on the submap loads their correct battlestage
- Snake
  - Loads their hidey hole once again
  - Random walkable encounters on the submap loads their correct battlestage
- Wardens (contact encounters)
  - Load the battleStage_, not their encounterDate[x].stage_03 (which is always 0)    


### Future

- Beyond me to consolidate these diverged flows further as I hit the script layer. ⛏️ 
- Feel like w/ some jank and the useBattleStage flag we could reduce the prepareEncounter() to one method but I think it still serves a point of 'overriding' the encounterId (debugger, scriptMapTransition's `scene` toxicity)