### PR TITLE
fix shopscreen crash if shop has no inventory to buy

### DIFF
--- a/src/main/java/legend/game/inventory/screens/ShopScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ShopScreen.java
@@ -698,6 +698,11 @@ public class ShopScreen extends MenuScreen {
   protected void handleSelectedMenu(final int i) {
     switch(i) {
       case 0 -> { // Buy
+        if(this.inv.isEmpty()) {
+          menuStack.pushScreen(new MessageBoxScreen("The shop has nothing\nto buy", 0, result -> {}));
+          return;
+        }
+
         this.selectedMenuOptionRenderablePtr_800bdbe4 = allocateUiElement(0x7b, 0x7b, 170, this.menuEntryY(this.menuIndex_8011e0e0));
         FUN_80104b60(this.selectedMenuOptionRenderablePtr_800bdbe4);
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bddbddd4-2340-4967-b547-23ef9175552b)

```
02:59:59.997 [Hardware legend.game.Main:80] ERROR: Stack trace:
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at legend.game.inventory.screens.ShopScreen.render(ShopScreen.java:186)
	at legend.game.inventory.screens.MenuScreen.renderScreen(MenuScreen.java:72)
	at legend.game.inventory.screens.MenuStack.propagate(MenuStack.java:128)
	at legend.game.inventory.screens.MenuStack.render(MenuStack.java:100)
	at legend.game.Scus94491BpeSegment_8002.loadAndRenderMenus(Scus94491BpeSegment_8002.java:810)
	at legend.game.Scus94491BpeSegment.lambda$gameLoop$46(Scus94491BpeSegment.java:416)
	at legend.core.RenderEngine.lambda$init$18(RenderEngine.java:609)
	at legend.core.opengl.Window$Events.onDraw(Window.java:792)
	at legend.core.opengl.Window.tickFrame(Window.java:432)
	at legend.core.opengl.Action.run(Action.java:46)
	at legend.core.opengl.Action.tick(Action.java:32)
	at legend.core.opengl.Window.run(Window.java:408)
	at legend.core.RenderEngine.run(RenderEngine.java:1008)
	at legend.core.GameEngine.start(GameEngine.java:256)
	at legend.game.Main.main(Main.java:40)
02:59:59.997 [Hardware legend.game.Main:82] ERROR: Please copy this crash log and send it to us in the Player Help channel in the Legend of Dragoon Discord server.
02:59:59.997 [Hardware legend.game.Main:83] ERROR: https://discord.gg/legendofdragoon
```

mods can set shops to be empty