### PR TITLE
Fix submapcutforsave not being set on campaign select (closes #2054)

### DIFF
--- a/src/main/java/legend/game/inventory/screens/CampaignSelectionScreen.java
+++ b/src/main/java/legend/game/inventory/screens/CampaignSelectionScreen.java
@@ -35,6 +35,7 @@ import static legend.game.Scus94491BpeSegment_8002.deallocateRenderables;
 import static legend.game.Scus94491BpeSegment_8002.playMenuSound;
 import static legend.game.Scus94491BpeSegment_8005.collidedPrimitiveIndex_80052c38;
 import static legend.game.Scus94491BpeSegment_8005.submapCut_80052c30;
+import static legend.game.Scus94491BpeSegment_8005.submapCutForSave_800cb450;
 import static legend.game.Scus94491BpeSegment_8005.submapScene_80052c34;
 import static legend.game.Scus94491BpeSegment_800b.gameState_800babc8;
 import static legend.game.Scus94491BpeSegment_800b.loadingNewGameState_800bdc34;
@@ -115,6 +116,7 @@ public class CampaignSelectionScreen extends MenuScreen {
 
       submapScene_80052c34 = gameState_800babc8.submapScene_a4;
       submapCut_80052c30 = gameState_800babc8.submapCut_a8;
+      submapCutForSave_800cb450 = submapCut_80052c30;
       collidedPrimitiveIndex_80052c38 = gameState_800babc8.submapCut_a8;
 
       if(gameState_800babc8.submapCut_a8 == 264) { // Somewhere in Home of Giganto


### PR DESCRIPTION
- On submap load the submapcutforsave does not get set when resuming a campaign from save
- Default value is 0
- New Campaign sets submapcutforsave so no issue there

Fixes debug submap saving in the Crash Recovery save if the crash occurred before mapTransition was called (earliest next call to set submapcutforsave).