### PR TITLE
Fix Load from Main Menu map transitions

### DIFF
--- a/src/main/java/legend/game/EngineState.java
+++ b/src/main/java/legend/game/EngineState.java
@@ -4,6 +4,7 @@ import legend.core.platform.input.InputAction;
 import legend.game.scripting.FlowControl;
 import legend.game.scripting.RunningScript;
 import legend.game.types.CContainer;
+import legend.game.types.GameState52c;
 import legend.game.types.Model124;
 import org.joml.Math;
 
@@ -100,6 +101,10 @@ public abstract class EngineState {
 
   public float getAnalogueMagnitude() {
     return this.analogueMagnitude;
+  }
+
+  public void loadGameFromMenu(final GameState52c gameState) {
+    throw new RuntimeException("Not implemented");
   }
 
   public enum RenderMode {

--- a/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
+++ b/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 
 import static legend.core.GameEngine.CONFIG;
@@ -43,6 +42,7 @@ import static legend.game.Scus94491BpeSegment_8002.deallocateRenderables;
 import static legend.game.Scus94491BpeSegment_8002.getTimestampPart;
 import static legend.game.Scus94491BpeSegment_8002.playMenuSound;
 import static legend.game.Scus94491BpeSegment_8002.renderText;
+import static legend.game.Scus94491BpeSegment_8004.currentEngineState_8004dd04;
 import static legend.game.Scus94491BpeSegment_8004.engineState_8004dd20;
 import static legend.game.Scus94491BpeSegment_8005.collidedPrimitiveIndex_80052c38;
 import static legend.game.Scus94491BpeSegment_8005.standingInSavePoint_8005a368;
@@ -362,7 +362,7 @@ public class MainMenuScreen extends MenuScreen {
       gameState_800babc8.syncIds();
 
       loadingNewGameState_800bdc34 = true;
-      whichMenu_800bdc38 = WhichMenu.UNLOAD;
+      whichMenu_800bdc38 = WhichMenu.UNLOAD_SAVE_GAME_MENU_20;
 
       submapScene_80052c34 = gameState_800babc8.submapScene_a4;
       submapCut_80052c30 = gameState_800babc8.submapCut_a8;
@@ -372,6 +372,8 @@ public class MainMenuScreen extends MenuScreen {
       if(gameState_800babc8.submapCut_a8 == 264) { // Somewhere in Home of Giganto
         submapScene_80052c34 = 53;
       }
+
+      currentEngineState_8004dd04.loadGameFromMenu(gameState_800babc8);
     }, () -> {
       menuStack.popScreen();
       this.fadeOutArrows();

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -45,6 +45,7 @@ import legend.game.types.AnmSpriteMetrics14;
 import legend.game.types.BackgroundType;
 import legend.game.types.CContainer;
 import legend.game.types.CharacterData2c;
+import legend.game.types.GameState52c;
 import legend.game.types.GsF_LIGHT;
 import legend.game.types.LodString;
 import legend.game.types.Model124;
@@ -381,6 +382,19 @@ public class SMap extends EngineState {
   @Override
   public void restoreMusicAfterMenu() {
     this.submap.startMusic();
+  }
+
+  @Override
+  public void loadGameFromMenu(final GameState52c gameState) {
+    this.smapLoadingStage_800cb430 = SubmapState.RENDER_SUBMAP_12;
+    this.transitioning_800f7e4c = false;
+
+    if(gameState.isOnWorldMap_4e4) {
+      this.mapTransition(0, submapScene_80052c34);
+    } else {
+      this.mapTransition(submapCut_80052c30, submapScene_80052c34);
+      this.restoreMusicAfterMenu();
+    }
   }
 
   @Override

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -28,6 +28,7 @@ import legend.game.modding.coremod.CoreMod;
 import legend.game.submap.EncounterRateMode;
 import legend.game.tim.Tim;
 import legend.game.types.CContainer;
+import legend.game.types.GameState52c;
 import legend.game.types.GsF_LIGHT;
 import legend.game.types.McqHeader;
 import legend.game.types.Model124;
@@ -411,6 +412,11 @@ public class WMap extends EngineState {
   @Override
   public void restoreMusicAfterMenu() {
     unloadSoundFile(8);
+  }
+
+  @Override
+  public void loadGameFromMenu(final GameState52c gameState) {
+    this.wmapState_800bb10c = gameState.isOnWorldMap_4e4 ? WmapState.INIT_0 : WmapState.TRANSITION_TO_SUBMAP_7;
   }
 
   @Override


### PR DESCRIPTION
The Psyche Bomb Trial bug is still a mystery, but this fixes world map loading and switching back to submap music when reloading the current submap.

Closes #2223
Closes #2224