### PR TITLE
Make collision rotation use local movement (closes #2153)

### DIFF
--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -135,6 +135,7 @@ public class CollisionGeometry {
 
       if(this.collidedPrimitiveIndex_800cbd94 != -1 && this.playerRotationWasUpdated_800d1a8c == 0 && updatePlayerRotationInterpolation) {
         this.playerRotationWasUpdated_800d1a8c = this.smap.tickMultiplier();
+        // Makes rotation calculation use player's local rotation (otherwise rotates when X is non-zero, GH#2316)
         this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(movement.x, Math.cos(coords.transforms.rotate.x) * movement.z) + MathHelper.PI, MathHelper.TWO_PI);
       }
     } else {

--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -135,7 +135,7 @@ public class CollisionGeometry {
 
       if(this.collidedPrimitiveIndex_800cbd94 != -1 && this.playerRotationWasUpdated_800d1a8c == 0 && updatePlayerRotationInterpolation) {
         this.playerRotationWasUpdated_800d1a8c = this.smap.tickMultiplier();
-        this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(Math.sin(coords.transforms.rotate.z) * movement.x, Math.cos(coords.transforms.rotate.x) * movement.z) + MathHelper.PI, MathHelper.TWO_PI);
+        this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(movement.x, Math.cos(coords.transforms.rotate.x) * movement.z) + MathHelper.PI, MathHelper.TWO_PI);
       }
     } else {
       //LAB_800e8954

--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -135,7 +135,7 @@ public class CollisionGeometry {
 
       if(this.collidedPrimitiveIndex_800cbd94 != -1 && this.playerRotationWasUpdated_800d1a8c == 0 && updatePlayerRotationInterpolation) {
         this.playerRotationWasUpdated_800d1a8c = this.smap.tickMultiplier();
-        this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(Math.cos(coords.transforms.rotate.z) * movement.x, Math.cos(coords.transforms.rotate.x) * movement.z) + MathHelper.PI, MathHelper.TWO_PI);
+        this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(Math.sin(coords.transforms.rotate.z) * movement.x, Math.cos(coords.transforms.rotate.x) * movement.z) + MathHelper.PI, MathHelper.TWO_PI);
       }
     } else {
       //LAB_800e8954

--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -116,7 +116,9 @@ public class CollisionGeometry {
    * @return Collision primitive index that this model is within
    */
   @Method(0x800e88a0L)
-  public int checkCollision(final boolean isNpc, final Vector3f position, final Vector3f movement, final boolean updatePlayerRotationInterpolation) {
+  public int checkCollision(final boolean isNpc, final GsCOORDINATE2 coords, final Vector3f movement, final boolean updatePlayerRotationInterpolation) {
+    final Vector3f position = coords.coord.transfer;
+
     if(isNpc) {
       return this.handleCollision(position.x, position.y, position.z, movement);
     }
@@ -133,7 +135,7 @@ public class CollisionGeometry {
 
       if(this.collidedPrimitiveIndex_800cbd94 != -1 && this.playerRotationWasUpdated_800d1a8c == 0 && updatePlayerRotationInterpolation) {
         this.playerRotationWasUpdated_800d1a8c = this.smap.tickMultiplier();
-        this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(movement.x, movement.z) + MathHelper.PI, MathHelper.TWO_PI);
+        this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(Math.cos(coords.transforms.rotate.z) * movement.x, Math.cos(coords.transforms.rotate.x) * movement.z) + MathHelper.PI, MathHelper.TWO_PI);
       }
     } else {
       //LAB_800e8954

--- a/src/main/java/legend/game/submap/CollisionGeometry.java
+++ b/src/main/java/legend/game/submap/CollisionGeometry.java
@@ -135,7 +135,7 @@ public class CollisionGeometry {
 
       if(this.collidedPrimitiveIndex_800cbd94 != -1 && this.playerRotationWasUpdated_800d1a8c == 0 && updatePlayerRotationInterpolation) {
         this.playerRotationWasUpdated_800d1a8c = this.smap.tickMultiplier();
-        // Makes rotation calculation use player's local rotation (otherwise rotates when X is non-zero, GH#2316)
+        // Cos on X makes rotation calculation use player's local rotation (otherwise rotates when X is non-zero, GH#2316)
         this.playerRotationAfterCollision_800d1a84 = MathHelper.floorMod(MathHelper.atan2(movement.x, Math.cos(coords.transforms.rotate.x) * movement.z) + MathHelper.PI, MathHelper.TWO_PI);
       }
     } else {

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -1191,7 +1191,7 @@ public class SMap extends EngineState {
       GTE.setTransforms(worldToScreenMatrix_800c3548);
       this.transformToWorldspace(worldspaceDeltaMovement, deltaMovement);
 
-      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.checkCollision(player.sobjIndex_12e != 0, playerModel.coord2_14.coord.transfer, worldspaceDeltaMovement, true);
+      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.checkCollision(player.sobjIndex_12e != 0, playerModel.coord2_14, worldspaceDeltaMovement, true);
       if(collidedPrimitiveIndex >= 0) {
         if(this.isWalkable(collidedPrimitiveIndex)) {
           player.finishInterpolatedMovement();
@@ -1412,7 +1412,7 @@ public class SMap extends EngineState {
       GTE.setTransforms(worldToScreenMatrix_800c3548);
       this.transformToWorldspace(movement, deltaMovement);
 
-      this.collisionGeometry_800cbe08.checkCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement, true);
+      this.collisionGeometry_800cbe08.checkCollision(sobj.sobjIndex_12e != 0, model.coord2_14, movement, true);
 
       //LAB_800def08
       angle = MathHelper.positiveAtan2(movement.z, movement.x);
@@ -3126,7 +3126,7 @@ public class SMap extends EngineState {
       }
 
       //LAB_800e2140
-      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.checkCollision(sobj.sobjIndex_12e != 0, model.coord2_14.coord.transfer, movement, false);
+      final int collidedPrimitiveIndex = this.collisionGeometry_800cbe08.checkCollision(sobj.sobjIndex_12e != 0, model.coord2_14, movement, false);
       if(collidedPrimitiveIndex >= 0 && this.isWalkable(collidedPrimitiveIndex)) {
         model.coord2_14.coord.transfer.x += movement.x / (2.0f / vsyncMode_8007a3b8);
         model.coord2_14.coord.transfer.y = movement.y;


### PR DESCRIPTION
Uses Dart's rotation relative to himself rather than relative to the world