### PR TITLE
Adjust Dragoon lvl and Character level events

### DIFF
--- a/src/main/java/legend/game/modding/events/characters/PostCharacterDragoonLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PostCharacterDragoonLevelUpEvent.java
@@ -1,10 +1,6 @@
 package legend.game.modding.events.characters;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import legend.game.characters.CharacterData2c;
-import legend.game.characters.StatType;
-import org.legendofdragoon.modloader.events.CancelableEvent;
 import org.legendofdragoon.modloader.events.Event;
 
 public class PostCharacterDragoonLevelUpEvent extends Event {

--- a/src/main/java/legend/game/modding/events/characters/PostCharacterDragoonLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PostCharacterDragoonLevelUpEvent.java
@@ -1,0 +1,16 @@
+package legend.game.modding.events.characters;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import legend.game.characters.CharacterData2c;
+import legend.game.characters.StatType;
+import org.legendofdragoon.modloader.events.CancelableEvent;
+import org.legendofdragoon.modloader.events.Event;
+
+public class PostCharacterDragoonLevelUpEvent extends Event {
+  public final CharacterData2c character;
+
+  public PostCharacterDragoonLevelUpEvent(final CharacterData2c character) {
+    this.character = character;
+  }
+}

--- a/src/main/java/legend/game/modding/events/characters/PostCharacterLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PostCharacterLevelUpEvent.java
@@ -1,0 +1,12 @@
+package legend.game.modding.events.characters;
+
+import legend.game.characters.CharacterData2c;
+import org.legendofdragoon.modloader.events.Event;
+
+public class PostCharacterLevelUpEvent extends Event {
+  public final CharacterData2c character;
+
+  public PostCharacterLevelUpEvent(final CharacterData2c character) {
+    this.character = character;
+  }
+}

--- a/src/main/java/legend/game/modding/events/characters/PreCharacterDragoonLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PreCharacterDragoonLevelUpEvent.java
@@ -6,13 +6,13 @@ import legend.game.characters.CharacterData2c;
 import legend.game.characters.StatType;
 import org.legendofdragoon.modloader.events.CancelableEvent;
 
-public class CharacterDragoonLevelUpEvent extends CancelableEvent {
+public class PreCharacterDragoonLevelUpEvent extends CancelableEvent {
   public final CharacterData2c character;
 
   public final Object2IntMap<StatType<?>> statsToAdd = new Object2IntOpenHashMap<>();
   public int levelsToAdd = 1;
 
-  public CharacterDragoonLevelUpEvent(final CharacterData2c character) {
+  public PreCharacterDragoonLevelUpEvent(final CharacterData2c character) {
     this.character = character;
   }
 }

--- a/src/main/java/legend/game/modding/events/characters/PreCharacterLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PreCharacterLevelUpEvent.java
@@ -6,13 +6,13 @@ import legend.game.characters.CharacterData2c;
 import legend.game.characters.StatType;
 import org.legendofdragoon.modloader.events.CancelableEvent;
 
-public class CharacterLevelUpEvent extends CancelableEvent {
+public class PreCharacterLevelUpEvent extends CancelableEvent {
   public final CharacterData2c character;
 
   public final Object2IntMap<StatType<?>> statsToAdd = new Object2IntOpenHashMap<>();
   public int levelsToAdd = 1;
 
-  public CharacterLevelUpEvent(final CharacterData2c character) {
+  public PreCharacterLevelUpEvent(final CharacterData2c character) {
     this.character = character;
   }
 }

--- a/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
+++ b/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
@@ -13,8 +13,10 @@ import legend.game.characters.StatCollection;
 import legend.game.characters.VitalsStat;
 import legend.game.combat.bent.PlayerBattleEntity;
 import legend.game.inventory.Good;
-import legend.game.modding.events.characters.CharacterDragoonLevelUpEvent;
-import legend.game.modding.events.characters.CharacterLevelUpEvent;
+import legend.game.modding.events.characters.PostCharacterDragoonLevelUpEvent;
+import legend.game.modding.events.characters.PostCharacterLevelUpEvent;
+import legend.game.modding.events.characters.PreCharacterDragoonLevelUpEvent;
+import legend.game.modding.events.characters.PreCharacterLevelUpEvent;
 import legend.game.saves.SavedCharacter;
 import legend.game.saves.SeveredSavedCharacterV2;
 import legend.game.textures.Image;
@@ -186,7 +188,7 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
 
   @Override
   public void applyLevelUp(final CharacterData2c character, @Nullable final LevelUpActions actions) {
-    final CharacterLevelUpEvent event = new CharacterLevelUpEvent(character);
+    final PreCharacterLevelUpEvent event = new PreCharacterLevelUpEvent(character);
 
     event.statsToAdd.put(HP_STAT.get(), this.getHpToAdd(character.level_12));
     event.statsToAdd.put(ATTACK_STAT.get(), this.getAttackToAdd(character.level_12));
@@ -204,11 +206,12 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
     character.level_12 += event.levelsToAdd;
 
     this.checkUnlocks(character, actions);
+    EVENTS.postEvent(new PostCharacterLevelUpEvent(character));
   }
 
   @Override
   public void applyDragoonLevelUp(final CharacterData2c character, @Nullable final LevelUpActions actions) {
-    final CharacterDragoonLevelUpEvent event = new CharacterDragoonLevelUpEvent(character);
+    final PreCharacterDragoonLevelUpEvent event = new PreCharacterDragoonLevelUpEvent(character);
 
     event.statsToAdd.put(MP_STAT.get(), this.getMpToAdd(character.dlevel_13));
     event.statsToAdd.put(SP_STAT.get(), this.getSpToAdd(character.dlevel_13));
@@ -226,6 +229,8 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
     character.dlevel_13 += event.levelsToAdd;
 
     this.checkUnlocks(character, actions);
+
+    EVENTS.postEvent(new PostCharacterDragoonLevelUpEvent(character));
   }
 
   @Override


### PR DESCRIPTION
- rename existing events to use "pre" prefix
- create new events for "post" events for purely informational handling.