### PR TITLE
Yeeted .gitignores from subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ gradle-app.setting
 
 # JDK files
 /jdk*
+
+/files/**
+/isos/**
+/saves/**
+/mods/**
+

--- a/files/.gitignore
+++ b/files/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/isos/.gitignore
+++ b/isos/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/mods/.gitignore
+++ b/mods/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/saves/.gitignore
+++ b/saves/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/src/main/java/legend/game/unpacker/Unpacker.java
+++ b/src/main/java/legend/game/unpacker/Unpacker.java
@@ -349,18 +349,9 @@ public final class Unpacker {
   }
 
   private static void deleteUnpack() throws IOException {
-    final Path gitIgnore = ROOT.resolve(".gitignore");
-
     try(final Stream<Path> files = Files.walk(ROOT)) {
       files
         .sorted(Comparator.reverseOrder())
-        .filter(path -> {
-          try {
-            return !Files.isSameFile(path, gitIgnore);
-          } catch(final IOException ignored) {
-            return true;
-          }
-        })
         .forEach(path -> {
           try {
             if(!Files.isSameFile(path, ROOT)) {


### PR DESCRIPTION
It should only really be in the root folder, it also allows the removal of handling from the unpack