### PR TITLE
Fix 0 byte updater.jar in distribution builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,8 @@ tasks.register('updaterJar', Jar) {
   archiveBaseName = 'updater'
   archiveVersion = ''
   archiveClassifier = ''
+  // Stage the updater jar outside build/libs so copySupportFiles doesn't copy it onto itself (which truncates it to 0 bytes)
+  destinationDirectory = layout.buildDirectory.dir("updater")
 
   manifest {
     attributes(


### PR DESCRIPTION
Fixes the overwrite of the updater file by placing it in a different dir