### PR TITLE
Refactor criteria check into public method

### DIFF
--- a/src/main/java/legend/game/characters/CharacterAdditionInfo.java
+++ b/src/main/java/legend/game/characters/CharacterAdditionInfo.java
@@ -56,12 +56,15 @@ public class CharacterAdditionInfo {
       return false;
     }
 
-    for(int i = 0; i < this.unlockCriteria.size(); i++) {
-      if(!this.unlockCriteria.get(i).isUnlocked(character, this)) {
-        return false;
-      }
-    }
+    return this.checkUnlockCriteria(character);
+  }
 
-    return true;
+  /**
+   * @param character - Character to validate unlock criteria against
+   *
+   * @return True if all criteria is met, false if not.
+   */
+  public boolean checkUnlockCriteria(final CharacterData2c character) {
+    return this.unlockCriteria.stream().allMatch(uc -> uc.isUnlocked(character, this));
   }
 }

--- a/src/main/java/legend/game/characters/CharacterSpellInfo.java
+++ b/src/main/java/legend/game/characters/CharacterSpellInfo.java
@@ -58,12 +58,15 @@ public class CharacterSpellInfo {
       return false;
     }
 
-    for(int i = 0; i < this.unlockCriteria.size(); i++) {
-      if(!this.unlockCriteria.get(i).isUnlocked(character, this)) {
-        return false;
-      }
-    }
+    return this.checkUnlockCriteria(character);
+  }
 
-    return true;
+  /**
+   * @param character - character to validate spell info against
+   *
+   * @return True if all criteria is met, false if not.
+   */
+  public boolean checkUnlockCriteria(final CharacterData2c character) {
+    return this.unlockCriteria.stream().allMatch(uc -> uc.isUnlocked(character, this));
   }
 }


### PR DESCRIPTION
Currently in archipelagoon in order to check if an addition or spell has met its unlock condition, i must do the following:
1) _set_ the info's unlock state to `Unlockable`  
2) call `checkUnlock`
3) set the info's unlock state back to what it was.

Its much easier for mods to have the ability to directly check the criteria without adjusting the unlock state.