### PR TITLE
add character element resolution event

### DIFF
--- a/src/main/java/legend/game/characters/CharacterData2c.java
+++ b/src/main/java/legend/game/characters/CharacterData2c.java
@@ -7,6 +7,7 @@ import legend.game.combat.bent.PlayerBattleEntity;
 import legend.game.inventory.CanEquip;
 import legend.game.inventory.Equipment;
 import legend.game.inventory.EquipmentTypes;
+import legend.game.modding.events.characters.ResolveCharacterElementEvent;
 import legend.game.types.EquipmentSlot;
 import legend.game.types.GameState52c;
 import org.legendofdragoon.modloader.registries.RegistryId;
@@ -21,6 +22,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static legend.core.GameEngine.EVENTS;
 
 public class CharacterData2c {
   public static final int IN_PARTY = 0x1;
@@ -201,11 +204,13 @@ public class CharacterData2c {
   }
 
   public Element getElement() {
-    return this.template.getElement(this);
+    final ResolveCharacterElementEvent event = EVENTS.postEvent(new ResolveCharacterElementEvent(this, null, this.template.getElement(this)));
+    return event.element;
   }
 
   public Element getElement(final PlayerBattleEntity bent) {
-    return this.template.getElement(this, bent);
+    final ResolveCharacterElementEvent event = EVENTS.postEvent(new ResolveCharacterElementEvent(this, bent, this.template.getElement(this, bent)));
+    return event.element;
   }
 
   public boolean hasDragoon() {

--- a/src/main/java/legend/game/modding/events/characters/ResolveCharacterElementEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/ResolveCharacterElementEvent.java
@@ -1,0 +1,32 @@
+package legend.game.modding.events.characters;
+
+import legend.game.characters.CharacterData2c;
+import legend.game.characters.Element;
+import legend.game.combat.bent.PlayerBattleEntity;
+import org.legendofdragoon.modloader.events.Event;
+
+import javax.annotation.Nullable;
+
+/**
+ * Fired when an element is resolved for a player character.
+ *
+ * <p>When {@link #bent} is {@code null}, the element is being resolved through the character
+ * flow. When it is present, the element is being resolved for that player battle entity.</p>
+ *
+ * <p>The base element is the result supplied by the character template. Listeners may replace
+ * {@link #element} with a resolved override.</p>
+ */
+public class ResolveCharacterElementEvent extends Event {
+  public final CharacterData2c character;
+  @Nullable
+  public final PlayerBattleEntity bent;
+  public final Element baseElement;
+  public Element element;
+
+  public ResolveCharacterElementEvent(final CharacterData2c character, @Nullable final PlayerBattleEntity bent, final Element baseElement) {
+    this.character = character;
+    this.bent = bent;
+    this.baseElement = baseElement;
+    this.element = baseElement;
+  }
+}


### PR DESCRIPTION
Notes
- template is public on CharacterData2c so the actual template element is still accessible outside of the getElement flow (which is now hooked by an event)
  - The event flow being bypassable seems like a feature to me
  - Wonder if there would be someway to tell modders that certain flows are 'event-dependent' vs 'non-event hooked' but hey if someone is accessing public properties over getters/setters maybe that is the warning haha 
- Main constraint on this approach are things like Dart having two elements to cater for and it ultimately being on the mod to handle game context stuff like that
- null usage
  - without null the better approach for the split getElement behaviour would be two different events
    - `ResolveCharacterElementEvent`
    - `ResolveBattleCharacterElementEvent`
  - imo easier for null to mean 'if bent is null, this is not a bent path' rather than splitting getElement in CharacterData2c and CharacterTemplate current usages
    - `getCharacterElement` and `getBattleEntityElement` might be too granular / confusing ... but happy to do it if preferred
  - added comment to explain the null either way