### PR TITLE
D-Spells Modding

### DIFF
--- a/patches/scripts/player_combat_script.txt
+++ b/patches/scripts/player_combat_script.txt
@@ -2642,6 +2642,9 @@ mov stor[0], stor[28] ; source, dest
 gosub inl[:LABEL_8] ; addr
 mov stor[18], stor[28] ; source, dest
 mov stor[20], stor[30] ; source, dest
+; Declarative spells dispatch every plan and target through Java, including target damage handlers.
+; The special-effects sentinel skips this retail damage path so the selected target is not hit twice.
+jmp_cmp ==, 0x80000000, stor[10], inl[:LABEL_286] ; declarative spell effects applied
 mov stor[8], stor[32] ; source, dest
 gosub inl[:APPLY_DAMAGE_SIMPLE] ; addr
 jmp_cmp &, 0x40, stor[7], inl[:LABEL_286] ; operand, left, right, addr

--- a/src/main/java/legend/game/combat/Battle.java
+++ b/src/main/java/legend/game/combat/Battle.java
@@ -337,7 +337,8 @@ import static legend.lodmod.LodMod.disableRetailBattleActions;
 public class Battle extends EngineState<Battle> {
   private static final int DECLARATIVE_SPELL_EFFECTS_APPLIED = Integer.MIN_VALUE;
   private static final int BENT_TAKE_DAMAGE_ENTRYPOINT = 2;
-  private static final int SCRIPT_DAMAGE_STORAGE = 32;
+  private static final int BENT_APPLY_STATUS_ENTRYPOINT = 10;
+  private static final int SCRIPT_EFFECT_ARGUMENT_STORAGE = 32;
   private static final Logger LOGGER = LogManager.getFormatterLogger(Battle.class);
   private static final Marker CAMERA = MarkerManager.getMarker("CAMERA");
   private static final Marker DEFF = MarkerManager.getMarker("DEFF");
@@ -8705,6 +8706,7 @@ public class Battle extends EngineState<Battle> {
       (target, power) -> this.calculateDeclarativeSpellDamage(attacker, target, power)
     );
     final Map<BattleEntity27c, Integer> damageByTarget = new LinkedHashMap<>();
+    final Map<BattleEntity27c, Integer> statusByTarget = new LinkedHashMap<>();
     final Map<BattleEntity27c, Integer> remainingHpByTarget = new LinkedHashMap<>();
     boolean dealsDamage = false;
 
@@ -8720,7 +8722,10 @@ public class Battle extends EngineState<Battle> {
       final int remainingHp = remainingHpByTarget.computeIfAbsent(target, bent -> bent.stats.getStat(HP_STAT.get()).getCurrent());
       final int appliedVitalLoss = java.lang.Math.min(prepared.damage(), remainingHp);
       remainingHpByTarget.put(target, remainingHp - appliedVitalLoss);
-      this.spellEffectExecutor.complete(attacker, target, prepared, seed_800fa754, appliedVitalLoss);
+      final int statusEffect = this.spellEffectExecutor.complete(attacker, target, prepared, seed_800fa754, appliedVitalLoss);
+      if(statusEffect > 0) {
+        statusByTarget.putIfAbsent(target, statusEffect);
+      }
       damageByTarget.merge(target, prepared.damage(), Integer::sum);
     }
 
@@ -8729,8 +8734,11 @@ public class Battle extends EngineState<Battle> {
     }
 
     for(final Map.Entry<BattleEntity27c, Integer> entry : damageByTarget.entrySet()) {
-      if(entry.getValue() > 0) {
-        this.applyDeclarativeSpellDamage(entry.getKey(), entry.getValue());
+      final BattleEntity27c target = entry.getKey();
+      final ScriptState<?> damageContinuation = entry.getValue() > 0 ? this.applyDeclarativeSpellDamage(target, entry.getValue()) : null;
+      final Integer statusEffect = statusByTarget.get(target);
+      if(statusEffect != null) {
+        this.applyDeclarativeSpellStatus(target, statusEffect, damageContinuation);
       }
     }
 
@@ -8756,11 +8764,33 @@ public class Battle extends EngineState<Battle> {
     return damage;
   }
 
-  private void applyDeclarativeSpellDamage(final BattleEntity27c target, final int damage) {
+  private ScriptState<?> applyDeclarativeSpellDamage(final BattleEntity27c target, final int damage) {
     final ScriptState<? extends BattleEntity27c> targetState = battleState_8006e398.allBents_e0c.get(target.allBentSlot_274);
-    targetState.fork();
+    final ScriptState<?> continuation = targetState.fork();
     targetState.frame().offset = targetState.frame().file.getEntry(BENT_TAKE_DAMAGE_ENTRYPOINT);
-    targetState.setStor(SCRIPT_DAMAGE_STORAGE, damage);
+    targetState.setStor(SCRIPT_EFFECT_ARGUMENT_STORAGE, damage);
+    return continuation;
+  }
+
+  private void applyDeclarativeSpellStatus(final BattleEntity27c target, final int statusEffect, final ScriptState<?> damageContinuation) {
+    final ScriptState<? extends BattleEntity27c> targetState = battleState_8006e398.allBents_e0c.get(target.allBentSlot_274);
+    final ScriptState<?> pendingStatus = SCRIPTS.allocateScriptState("Declarative spell status", null);
+    pendingStatus.setTicker((state, ignored) -> {
+      if(SCRIPTS.getState(targetState.index) != targetState) {
+        state.deallocate();
+        return;
+      }
+
+      // The damage script consumes this continuation after shields, HP loss, and death handling.
+      if(damageContinuation != null && SCRIPTS.getState(damageContinuation.index) == damageContinuation) return;
+
+      if(target.stats.getStat(HP_STAT.get()).getCurrent() > 0) {
+        targetState.fork();
+        targetState.frame().offset = targetState.frame().file.getEntry(BENT_APPLY_STATUS_ENTRYPOINT);
+        targetState.setStor(SCRIPT_EFFECT_ARGUMENT_STORAGE, Integer.numberOfTrailingZeros(statusEffect));
+      }
+      state.deallocate();
+    });
   }
 
   private void validateDeclarativeSpellTargeting(final SpellStats0c spell, final List<SpellEffectPlan> plans) {

--- a/src/main/java/legend/game/combat/Battle.java
+++ b/src/main/java/legend/game/combat/Battle.java
@@ -173,7 +173,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -333,6 +335,9 @@ import static legend.lodmod.LodMod.SP_STAT;
 import static legend.lodmod.LodMod.disableRetailBattleActions;
 
 public class Battle extends EngineState<Battle> {
+  private static final int DECLARATIVE_SPELL_EFFECTS_APPLIED = Integer.MIN_VALUE;
+  private static final int BENT_TAKE_DAMAGE_ENTRYPOINT = 2;
+  private static final int SCRIPT_DAMAGE_STORAGE = 32;
   private static final Logger LOGGER = LogManager.getFormatterLogger(Battle.class);
   private static final Marker CAMERA = MarkerManager.getMarker("CAMERA");
   private static final Marker DEFF = MarkerManager.getMarker("DEFF");
@@ -428,6 +433,7 @@ public class Battle extends EngineState<Battle> {
 
   private final Object usedMonsterTextureSlotsLock = new Object();
   private final SpellEffectExecutor spellEffectExecutor = new SpellEffectExecutor();
+  private DeclarativeSpellCast declarativeSpellCast;
   private int usedMonsterTextureSlots_800c66c4;
   public ScriptState<? extends BattleEntity27c> currentTurnBent_800c66c8;
   private int mcqBaseOffsetX_800c66cc;
@@ -614,6 +620,9 @@ public class Battle extends EngineState<Battle> {
   public final SoundFile deffSounds = addSoundFile("DEFF SFX");
   public final SoundFile cutsceneSounds = addSoundFile("Cutscene SFX");
   public final SoundFile attackSounds = addSoundFile("Attack SFX");
+
+  private record DeclarativeSpellCast(int turnCount, int attackerIndex, RegistryId spellId) { }
+  private record DeclarativeSpellResult(int damage, int specialEffects) { }
 
   public Battle() {
     super(LodEngineStateTypes.BATTLE.get());
@@ -8651,28 +8660,11 @@ public class Battle extends EngineState<Battle> {
     attacker.clearTempWeaponAndSpellStats();
     attacker.setActiveSpell(script.params_20[2].get());
 
-    if(attacker instanceof final PlayerBattleEntity player) {
-      final SpellEffectPlan plan = this.declarativeSpellPlan(player, defender);
-      if(plan != null) {
-        final SpellEffectPlan primaryPlan = attacker.spell_94.getEffectPlans().get(0);
-        if(primaryPlan.executionMode() == ExecutionMode.DECLARATIVE) {
-          this.validateDeclarativeSpellTargeting(attacker.spell_94, primaryPlan);
-        }
-
-        var prepared = this.spellEffectExecutor.prepare(player, defender, plan, power -> this.calculateDeclarativeSpellDamage(player, defender, power));
-        final boolean dealsDamage = plan.effects().stream().anyMatch(DamageSpellEffect.class::isInstance);
-        final int eventDamage = EVENTS.postEvent(new AttackEvent(this, attacker, defender, AttackType.DRAGOON_MAGIC_STATUS_ITEMS, prepared.damage())).damage;
-        if(dealsDamage) {
-          prepared = new SpellEffectExecutor.PreparedSpellEffects(plan, java.lang.Math.max(0, eventDamage));
-          this.addElementIcon(attacker.spell_94.element_08.get());
-        }
-
-        final int appliedVitalLoss = java.lang.Math.min(prepared.damage(), defender.stats.getStat(HP_STAT.get()).getCurrent());
-        final int specialEffects = this.spellEffectExecutor.complete(player, defender, prepared, seed_800fa754, appliedVitalLoss);
-        script.params_20[3].set(prepared.damage());
-        script.params_20[4].set(specialEffects);
-        return FlowControl.CONTINUE;
-      }
+    if(attacker instanceof final PlayerBattleEntity player && attacker.spell_94.getEffectPlans().stream().anyMatch(plan -> plan.executionMode() == ExecutionMode.DECLARATIVE)) {
+      final DeclarativeSpellResult result = this.executeDeclarativeSpell(player, defender);
+      script.params_20[3].set(result.damage());
+      script.params_20[4].set(result.specialEffects());
+      return FlowControl.CONTINUE;
     }
 
     int damage = this.calculateMagicDamage(attacker, defender, 1);
@@ -8696,6 +8688,55 @@ public class Battle extends EngineState<Battle> {
     return FlowControl.CONTINUE;
   }
 
+  private DeclarativeSpellResult executeDeclarativeSpell(final PlayerBattleEntity attacker, final BattleEntity27c selectedTarget) {
+    final DeclarativeSpellCast cast = new DeclarativeSpellCast(gameState_800babc8.turnCount_b8, attacker.allBentSlot_274, attacker.spell_94.getRegistryId());
+    if(cast.equals(this.declarativeSpellCast)) {
+      return new DeclarativeSpellResult(0, DECLARATIVE_SPELL_EFFECTS_APPLIED);
+    }
+
+    this.declarativeSpellCast = cast;
+    this.validateDeclarativeSpellTargeting(attacker.spell_94, attacker.spell_94.getEffectPlans());
+    final List<? extends BattleEntity27c> battleEntities = battleState_8006e398.allBents_e0c.stream().map(state -> state.innerStruct_00).toList();
+    final List<SpellEffectExecutor.TargetedSpellEffects> preparedEffects = this.spellEffectExecutor.prepare(
+      attacker,
+      selectedTarget,
+      battleEntities,
+      attacker.spell_94.getEffectPlans(),
+      (target, power) -> this.calculateDeclarativeSpellDamage(attacker, target, power)
+    );
+    final Map<BattleEntity27c, Integer> damageByTarget = new LinkedHashMap<>();
+    final Map<BattleEntity27c, Integer> remainingHpByTarget = new LinkedHashMap<>();
+    boolean dealsDamage = false;
+
+    for(final SpellEffectExecutor.TargetedSpellEffects targeted : preparedEffects) {
+      final BattleEntity27c target = targeted.target();
+      var prepared = targeted.effects();
+      if(prepared.plan().effects().stream().anyMatch(DamageSpellEffect.class::isInstance)) {
+        dealsDamage = true;
+        final int eventDamage = EVENTS.postEvent(new AttackEvent(this, attacker, target, AttackType.DRAGOON_MAGIC_STATUS_ITEMS, prepared.damage())).damage;
+        prepared = new SpellEffectExecutor.PreparedSpellEffects(prepared.plan(), java.lang.Math.max(0, eventDamage));
+      }
+
+      final int remainingHp = remainingHpByTarget.computeIfAbsent(target, bent -> bent.stats.getStat(HP_STAT.get()).getCurrent());
+      final int appliedVitalLoss = java.lang.Math.min(prepared.damage(), remainingHp);
+      remainingHpByTarget.put(target, remainingHp - appliedVitalLoss);
+      this.spellEffectExecutor.complete(attacker, target, prepared, seed_800fa754, appliedVitalLoss);
+      damageByTarget.merge(target, prepared.damage(), Integer::sum);
+    }
+
+    if(dealsDamage) {
+      this.addElementIcon(attacker.spell_94.element_08.get());
+    }
+
+    for(final Map.Entry<BattleEntity27c, Integer> entry : damageByTarget.entrySet()) {
+      if(entry.getValue() > 0) {
+        this.applyDeclarativeSpellDamage(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return new DeclarativeSpellResult(0, DECLARATIVE_SPELL_EFFECTS_APPLIED);
+  }
+
   private int calculateDeclarativeSpellDamage(final PlayerBattleEntity attacker, final BattleEntity27c defender, final int power) {
     final Element attackElement = attacker.spell_94.element_08.get();
     final AttackType attackType = AttackType.DRAGOON_MAGIC_STATUS_ITEMS;
@@ -8715,59 +8756,24 @@ public class Battle extends EngineState<Battle> {
     return damage;
   }
 
-  private SpellEffectPlan declarativeSpellPlan(final PlayerBattleEntity attacker, final BattleEntity27c defender) {
-    boolean hasDeclarativePlan = false;
-    for(final SpellEffectPlan plan : attacker.spell_94.getEffectPlans()) {
-      if(plan.executionMode() != ExecutionMode.DECLARATIVE) {
-        continue;
-      }
-
-      hasDeclarativePlan = true;
-      if(this.matchesDeclarativeSpellTarget(attacker, defender, plan)) {
-        return plan;
-      }
-    }
-
-    if(hasDeclarativePlan) {
-      throw new IllegalStateException("Declarative spell " + attacker.spell_94.getRegistryId() + " has no plan for target " + defender.getClass().getSimpleName());
-    }
-
-    return null;
+  private void applyDeclarativeSpellDamage(final BattleEntity27c target, final int damage) {
+    final ScriptState<? extends BattleEntity27c> targetState = battleState_8006e398.allBents_e0c.get(target.allBentSlot_274);
+    targetState.fork();
+    targetState.frame().offset = targetState.frame().file.getEntry(BENT_TAKE_DAMAGE_ENTRYPOINT);
+    targetState.setStor(SCRIPT_DAMAGE_STORAGE, damage);
   }
 
-  private boolean matchesDeclarativeSpellTarget(final PlayerBattleEntity attacker, final BattleEntity27c defender, final SpellEffectPlan plan) {
-    final boolean sideMatches = switch(plan.target().side()) {
-      case SELF -> attacker == defender;
-      case ALLIES -> defender instanceof PlayerBattleEntity;
-      case ENEMIES -> !(defender instanceof PlayerBattleEntity);
-      case ANY -> true;
-    };
-
-    if(!sideMatches) {
-      return false;
-    }
-
-    final boolean living = defender.stats.getStat(HP_STAT.get()).getCurrent() > 0;
-    return switch(plan.target().lifeState()) {
-      case LIVING -> living;
-      case DEAD -> !living;
-      case ANY -> true;
-    };
-  }
-
-  private void validateDeclarativeSpellTargeting(final SpellStats0c spell, final SpellEffectPlan plan) {
+  private void validateDeclarativeSpellTargeting(final SpellStats0c spell, final List<SpellEffectPlan> plans) {
     final boolean targetsAll = (spell.targetType_00 & 0x8) != 0;
-    if(targetsAll != (plan.target().scope() == TargetScope.ALL)) {
-      throw new IllegalStateException("Declarative spell " + spell.getRegistryId() + " target scope does not match its resolved target metadata");
-    }
-
     final boolean targetsEnemies = (spell.targetType_00 & 0x40) != 0;
-    if(plan.target().side() == TargetSide.ENEMIES && !targetsEnemies) {
-      throw new IllegalStateException("Declarative spell " + spell.getRegistryId() + " enemy target side does not match its resolved target metadata");
-    }
-
-    if((plan.target().side() == TargetSide.SELF || plan.target().side() == TargetSide.ALLIES) && targetsEnemies) {
-      throw new IllegalStateException("Declarative spell " + spell.getRegistryId() + " friendly target side does not match its resolved target metadata");
+    final boolean hasMenuTargetPlan = plans.stream()
+      .filter(plan -> plan.executionMode() == ExecutionMode.DECLARATIVE)
+      .anyMatch(plan ->
+        targetsAll == (plan.target().scope() == TargetScope.ALL) &&
+          (plan.target().side() == TargetSide.ANY || targetsEnemies == (plan.target().side() == TargetSide.ENEMIES))
+      );
+    if(!hasMenuTargetPlan) {
+      throw new IllegalStateException("Declarative spell " + spell.getRegistryId() + " has no plan matching its resolved target metadata");
     }
   }
 

--- a/src/main/java/legend/game/combat/Battle.java
+++ b/src/main/java/legend/game/combat/Battle.java
@@ -39,6 +39,12 @@ import legend.game.combat.bent.ElementIcon;
 import legend.game.combat.bent.MonsterBattleEntity;
 import legend.game.combat.bent.PlayerBattleEntity;
 import legend.game.combat.bent.SetBattleEntityStatEvent;
+import legend.game.combat.spells.DamageSpellEffect;
+import legend.game.combat.spells.ExecutionMode;
+import legend.game.combat.spells.SpellEffectExecutor;
+import legend.game.combat.spells.SpellEffectPlan;
+import legend.game.combat.spells.TargetScope;
+import legend.game.combat.spells.TargetSide;
 import legend.game.combat.deff.Anim;
 import legend.game.combat.deff.DeffManager7cc;
 import legend.game.combat.deff.DeffPart;
@@ -421,6 +427,7 @@ public class Battle extends EngineState<Battle> {
   public ScriptState<? extends BattleEntity27c> forcedTurnBent_800c66bc;
 
   private final Object usedMonsterTextureSlotsLock = new Object();
+  private final SpellEffectExecutor spellEffectExecutor = new SpellEffectExecutor();
   private int usedMonsterTextureSlots_800c66c4;
   public ScriptState<? extends BattleEntity27c> currentTurnBent_800c66c8;
   private int mcqBaseOffsetX_800c66cc;
@@ -8644,6 +8651,30 @@ public class Battle extends EngineState<Battle> {
     attacker.clearTempWeaponAndSpellStats();
     attacker.setActiveSpell(script.params_20[2].get());
 
+    if(attacker instanceof final PlayerBattleEntity player) {
+      final SpellEffectPlan plan = this.declarativeSpellPlan(player, defender);
+      if(plan != null) {
+        final SpellEffectPlan primaryPlan = attacker.spell_94.getEffectPlans().get(0);
+        if(primaryPlan.executionMode() == ExecutionMode.DECLARATIVE) {
+          this.validateDeclarativeSpellTargeting(attacker.spell_94, primaryPlan);
+        }
+
+        var prepared = this.spellEffectExecutor.prepare(player, defender, plan, power -> this.calculateDeclarativeSpellDamage(player, defender, power));
+        final boolean dealsDamage = plan.effects().stream().anyMatch(DamageSpellEffect.class::isInstance);
+        final int eventDamage = EVENTS.postEvent(new AttackEvent(this, attacker, defender, AttackType.DRAGOON_MAGIC_STATUS_ITEMS, prepared.damage())).damage;
+        if(dealsDamage) {
+          prepared = new SpellEffectExecutor.PreparedSpellEffects(plan, java.lang.Math.max(0, eventDamage));
+          this.addElementIcon(attacker.spell_94.element_08.get());
+        }
+
+        final int appliedVitalLoss = java.lang.Math.min(prepared.damage(), defender.stats.getStat(HP_STAT.get()).getCurrent());
+        final int specialEffects = this.spellEffectExecutor.complete(player, defender, prepared, seed_800fa754, appliedVitalLoss);
+        script.params_20[3].set(prepared.damage());
+        script.params_20[4].set(specialEffects);
+        return FlowControl.CONTINUE;
+      }
+    }
+
     int damage = this.calculateMagicDamage(attacker, defender, 1);
     damage = applyMagicDamageMultiplier(attacker, defender, damage, 0);
     damage = java.lang.Math.max(1, damage);
@@ -8663,6 +8694,81 @@ public class Battle extends EngineState<Battle> {
     script.params_20[3].set(damage);
     script.params_20[4].set(this.determineAttackSpecialEffects(attacker, defender, AttackType.DRAGOON_MAGIC_STATUS_ITEMS));
     return FlowControl.CONTINUE;
+  }
+
+  private int calculateDeclarativeSpellDamage(final PlayerBattleEntity attacker, final BattleEntity27c defender, final int power) {
+    final Element attackElement = attacker.spell_94.element_08.get();
+    final AttackType attackType = AttackType.DRAGOON_MAGIC_STATUS_ITEMS;
+    int damage = attacker.calculateMagicDamage(defender, 0);
+    damage = attackElement.adjustAttackingElementalDamage(attackType, damage, defender.getElement());
+    damage = defender.getElement().adjustDefendingElementalDamage(attackType, damage, attackElement);
+    damage = adjustDamageForPower(damage, attacker.powerMagicAttack_b6, defender.powerMagicDefence_ba);
+    if(this.dragoonSpaceElement_800c6b64 != null) {
+      damage = attackElement.adjustDragoonSpaceDamage(attackType, damage, this.dragoonSpaceElement_800c6b64);
+    }
+
+    // Declarative power uses the retail 25 = 1x scale and replaces the legacy damage multiplier.
+    damage = damage * power / 25;
+    damage = java.lang.Math.max(1, damage);
+    damage = defender.applyDamageResistanceAndImmunity(damage, attackType);
+    damage = defender.applyElementalResistanceAndImmunity(damage, attackElement);
+    return damage;
+  }
+
+  private SpellEffectPlan declarativeSpellPlan(final PlayerBattleEntity attacker, final BattleEntity27c defender) {
+    boolean hasDeclarativePlan = false;
+    for(final SpellEffectPlan plan : attacker.spell_94.getEffectPlans()) {
+      if(plan.executionMode() != ExecutionMode.DECLARATIVE) {
+        continue;
+      }
+
+      hasDeclarativePlan = true;
+      if(this.matchesDeclarativeSpellTarget(attacker, defender, plan)) {
+        return plan;
+      }
+    }
+
+    if(hasDeclarativePlan) {
+      throw new IllegalStateException("Declarative spell " + attacker.spell_94.getRegistryId() + " has no plan for target " + defender.getClass().getSimpleName());
+    }
+
+    return null;
+  }
+
+  private boolean matchesDeclarativeSpellTarget(final PlayerBattleEntity attacker, final BattleEntity27c defender, final SpellEffectPlan plan) {
+    final boolean sideMatches = switch(plan.target().side()) {
+      case SELF -> attacker == defender;
+      case ALLIES -> defender instanceof PlayerBattleEntity;
+      case ENEMIES -> !(defender instanceof PlayerBattleEntity);
+      case ANY -> true;
+    };
+
+    if(!sideMatches) {
+      return false;
+    }
+
+    final boolean living = defender.stats.getStat(HP_STAT.get()).getCurrent() > 0;
+    return switch(plan.target().lifeState()) {
+      case LIVING -> living;
+      case DEAD -> !living;
+      case ANY -> true;
+    };
+  }
+
+  private void validateDeclarativeSpellTargeting(final SpellStats0c spell, final SpellEffectPlan plan) {
+    final boolean targetsAll = (spell.targetType_00 & 0x8) != 0;
+    if(targetsAll != (plan.target().scope() == TargetScope.ALL)) {
+      throw new IllegalStateException("Declarative spell " + spell.getRegistryId() + " target scope does not match its resolved target metadata");
+    }
+
+    final boolean targetsEnemies = (spell.targetType_00 & 0x40) != 0;
+    if(plan.target().side() == TargetSide.ENEMIES && !targetsEnemies) {
+      throw new IllegalStateException("Declarative spell " + spell.getRegistryId() + " enemy target side does not match its resolved target metadata");
+    }
+
+    if((plan.target().side() == TargetSide.SELF || plan.target().side() == TargetSide.ALLIES) && targetsEnemies) {
+      throw new IllegalStateException("Declarative spell " + spell.getRegistryId() + " friendly target side does not match its resolved target metadata");
+    }
   }
 
   @ScriptDescription("Perform a battle entity's item attack against another battle entity")

--- a/src/main/java/legend/game/combat/Battle.java
+++ b/src/main/java/legend/game/combat/Battle.java
@@ -114,6 +114,7 @@ import legend.game.modding.events.battle.EnemyRewardsEvent;
 import legend.game.modding.events.battle.LoadDeffEvent;
 import legend.game.modding.events.battle.LoadEnemyEvent;
 import legend.game.modding.events.battle.MonsterStatsEvent;
+import legend.game.modding.events.battle.SpellStatsEvent;
 import legend.game.scripting.FlowControl;
 import legend.game.scripting.Param;
 import legend.game.scripting.RunningScript;
@@ -8389,7 +8390,9 @@ public class Battle extends EngineState<Battle> {
       this.dragoonSpells_800c6960.add(spells);
 
       for(final RegistryId spellId : player.character.getUnlockedSpells()) {
-        spells.spells_01.add(REGISTRIES.spells.getEntry(spellId).get());
+        final SpellStats0c spell = REGISTRIES.spells.getEntry(spellId).get();
+        final SpellStatsEvent spellStatsEvent = EVENTS.postEvent(new SpellStatsEvent(player.character, spell));
+        spells.spells_01.add(spellStatsEvent.spell);
       }
 
       //LAB_800ef400

--- a/src/main/java/legend/game/combat/bent/BattleEntity27c.java
+++ b/src/main/java/legend/game/combat/bent/BattleEntity27c.java
@@ -17,6 +17,7 @@ import legend.game.combat.types.BattleSoundUsage;
 import legend.game.combat.types.CombatantStruct1a8;
 import legend.game.inventory.ItemStack;
 import legend.game.inventory.SpellStats0c;
+import legend.game.combat.spells.SpellEffectExecutor;
 import legend.game.modding.events.battle.ActiveItemEvent;
 import legend.game.modding.events.battle.ActiveSpellEvent;
 import legend.game.modding.events.battle.RegisterBattleEntityStatsEvent;
@@ -213,6 +214,7 @@ public abstract class BattleEntity27c extends BattleObject {
   public int tempPhysicalImmunityTurns_c5;
   public int tempMagicalImmunity_c6;
   public int tempMagicalImmunityTurns_c7;
+  public final SpellEffectExecutor.RegenState spellRegen = new SpellEffectExecutor.RegenState();
 
   public ItemStack item_d4;
 //  public int _ec;
@@ -304,9 +306,6 @@ public abstract class BattleEntity27c extends BattleObject {
   }
 
   public abstract int calculatePhysicalDamage(final BattleEntity27c target);
-  /**
-   * @param magicType item (0), spell (1)
-   */
   public abstract int calculateMagicDamage(final BattleEntity27c target, final int magicType);
 
   public int applyPhysicalDamageMultipliers(final BattleEntity27c target, final int damage) {
@@ -351,6 +350,7 @@ public abstract class BattleEntity27c extends BattleObject {
   }
 
   public void turnFinished() {
+    this.spellRegen.turnFinished(this);
     if(this.powerAttackTurns_b5 > 0) {
       this.powerAttackTurns_b5--;
 

--- a/src/main/java/legend/game/combat/bent/BattleEntity27c.java
+++ b/src/main/java/legend/game/combat/bent/BattleEntity27c.java
@@ -214,7 +214,8 @@ public abstract class BattleEntity27c extends BattleObject {
   public int tempPhysicalImmunityTurns_c5;
   public int tempMagicalImmunity_c6;
   public int tempMagicalImmunityTurns_c7;
-  public final SpellEffectExecutor.RegenState spellRegen = new SpellEffectExecutor.RegenState();
+    /** Active declarative spell regeneration, updated after this entity completes a turn. */
+    public final SpellEffectExecutor.RegenState spellRegen = new SpellEffectExecutor.RegenState();
 
   public ItemStack item_d4;
 //  public int _ec;

--- a/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
+++ b/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
@@ -595,6 +595,7 @@ public class PlayerBattleEntity extends BattleEntity27c {
       spell = LodSpells.SPELL127.get();
     }
 
-    this.spell_94 = EVENTS.postEvent(new SpellStatsEvent(gameState_800babc8.charData_32c.get(this.charId_272), spell)).spell;
+    final SpellStatsEvent spellStatsEvent = EVENTS.postEvent(new SpellStatsEvent(this.character, spell));
+    this.spell_94 = spellStatsEvent.spell;
   }
 }

--- a/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
+++ b/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
@@ -226,6 +226,7 @@ public class PlayerBattleEntity extends BattleEntity27c {
   @Method(0x800f2e98L)
   public int calculateMagicDamage(final BattleEntity27c target, final int magicType) {
     int matk = this.stats.getStat(MAGIC_ATTACK_STAT.get()).get();
+
     if(magicType == 1) {
       matk += this.spell_94.multi_04;
     }

--- a/src/main/java/legend/game/combat/spells/ApplyStatusSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/ApplyStatusSpellEffect.java
@@ -1,2 +1,9 @@
 package legend.game.combat.spells;
+/**
+ * Attempts to apply one status represented by {@code statusMask} after damage and drain effects.
+ *
+ * @param statusMask status bits eligible for application; only the highest set bit in the low
+ *                   eight bits is returned when the roll succeeds
+ * @param chance percent chance to apply the status, normally from {@code 0} through {@code 100}
+ */
 public record ApplyStatusSpellEffect(int statusMask, int chance) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/ApplyStatusSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/ApplyStatusSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record ApplyStatusSpellEffect(int statusMask, int chance) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/CleanseSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/CleanseSpellEffect.java
@@ -1,2 +1,7 @@
 package legend.game.combat.spells;
+/**
+ * Clears the selected status bits from each matched target before restoration and damage effects.
+ *
+ * @param statusMask status bits to clear
+ */
 public record CleanseSpellEffect(int statusMask) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/CleanseSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/CleanseSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record CleanseSpellEffect(int statusMask) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DamageSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DamageSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record DamageSpellEffect(int power) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DamageSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DamageSpellEffect.java
@@ -1,2 +1,10 @@
 package legend.game.combat.spells;
+/**
+ * Contributes power to the spell damage calculated for each matched target.
+ *
+ * <p>Multiple damage effects in one plan have their power values added before damage is
+ * calculated.</p>
+ *
+ * @param power power supplied to the battle damage calculation
+ */
 public record DamageSpellEffect(int power) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DrainHpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DrainHpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record DrainHpSpellEffect(int percent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DrainHpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DrainHpSpellEffect.java
@@ -1,2 +1,7 @@
 package legend.game.combat.spells;
+/**
+ * Restores the caster's HP from the damage actually applied to the target.
+ *
+ * @param percent percent of applied damage restored to the caster
+ */
 public record DrainHpSpellEffect(int percent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DrainMpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DrainMpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record DrainMpSpellEffect(int percent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DrainMpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DrainMpSpellEffect.java
@@ -1,2 +1,7 @@
 package legend.game.combat.spells;
+/**
+ * Restores the caster's MP from the damage actually applied to the target.
+ *
+ * @param percent percent of applied damage restored to the caster
+ */
 public record DrainMpSpellEffect(int percent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DrainSpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DrainSpSpellEffect.java
@@ -1,2 +1,7 @@
 package legend.game.combat.spells;
+/**
+ * Restores the caster's SP from the damage actually applied to the target.
+ *
+ * @param percent percent of applied damage restored to the caster
+ */
 public record DrainSpSpellEffect(int percent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/DrainSpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/DrainSpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record DrainSpSpellEffect(int percent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/ExecutionMode.java
+++ b/src/main/java/legend/game/combat/spells/ExecutionMode.java
@@ -1,2 +1,17 @@
 package legend.game.combat.spells;
-public enum ExecutionMode { LEGACY, DECLARATIVE, LEGACY_RAW }
+/** Defines which runtime interprets a {@link SpellEffectPlan}. */
+public enum ExecutionMode {
+    /** Uses the spell's retail fields and script behavior; declarative effects are not executed. */
+    LEGACY,
+
+    /** Executes the plan's {@link SpellEffect} values through the declarative spell runtime. */
+    DECLARATIVE,
+
+    /**
+     * Uses legacy runtime behavior for spell stats that no longer represent retail-safe values.
+     *
+     * <p>This currently executes through the same legacy path as {@link #LEGACY}; the distinct
+     * value preserves the stats' raw provenance for consumers.</p>
+     */
+    LEGACY_RAW,
+}

--- a/src/main/java/legend/game/combat/spells/ExecutionMode.java
+++ b/src/main/java/legend/game/combat/spells/ExecutionMode.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public enum ExecutionMode { LEGACY, DECLARATIVE, LEGACY_RAW }

--- a/src/main/java/legend/game/combat/spells/HealHpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/HealHpSpellEffect.java
@@ -1,2 +1,8 @@
 package legend.game.combat.spells;
+/**
+ * Restores HP to each matched living target, up to that target's maximum HP.
+ *
+ * @param potency flat HP restored, or percent of maximum HP when {@code percentage} is true
+ * @param percentage whether {@code potency} is a percentage of the target's maximum HP
+ */
 public record HealHpSpellEffect(int potency, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/HealHpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/HealHpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record HealHpSpellEffect(int potency, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RegenHpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RegenHpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record RegenHpSpellEffect(int potency, int turns, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RegenHpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RegenHpSpellEffect.java
@@ -1,2 +1,10 @@
 package legend.game.combat.spells;
+/**
+ * Replaces the target's current HP regeneration with a new turn-based regeneration effect.
+ *
+ * @param potency flat HP restored per turn, or percent of maximum HP when {@code percentage} is
+ *                true
+ * @param turns number of completed turns that apply the regeneration
+ * @param percentage whether {@code potency} is a percentage of the target's maximum HP
+ */
 public record RegenHpSpellEffect(int potency, int turns, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RegenMpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RegenMpSpellEffect.java
@@ -1,2 +1,12 @@
 package legend.game.combat.spells;
+/**
+ * Replaces the target's current MP regeneration with a new turn-based regeneration effect.
+ *
+ * <p>MP regeneration is applied only to player targets.</p>
+ *
+ * @param potency flat MP restored per turn, or percent of maximum MP when {@code percentage} is
+ *                true
+ * @param turns number of completed turns that apply the regeneration
+ * @param percentage whether {@code potency} is a percentage of the target's maximum MP
+ */
 public record RegenMpSpellEffect(int potency, int turns, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RegenMpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RegenMpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record RegenMpSpellEffect(int potency, int turns, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RegenSpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RegenSpSpellEffect.java
@@ -1,2 +1,12 @@
 package legend.game.combat.spells;
+/**
+ * Replaces the target's current SP regeneration with a new turn-based regeneration effect.
+ *
+ * <p>SP regeneration is applied only to player targets.</p>
+ *
+ * @param potency flat SP restored per turn, or percent of maximum SP when {@code percentage} is
+ *                true
+ * @param turns number of completed turns that apply the regeneration
+ * @param percentage whether {@code potency} is a percentage of the target's maximum SP
+ */
 public record RegenSpSpellEffect(int potency, int turns, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RegenSpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RegenSpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record RegenSpSpellEffect(int potency, int turns, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RestoreMpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RestoreMpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record RestoreMpSpellEffect(int potency, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RestoreMpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RestoreMpSpellEffect.java
@@ -1,2 +1,8 @@
 package legend.game.combat.spells;
+/**
+ * Restores MP to each matched player target, up to that target's maximum MP.
+ *
+ * @param potency flat MP restored, or percent of maximum MP when {@code percentage} is true
+ * @param percentage whether {@code potency} is a percentage of the target's maximum MP
+ */
 public record RestoreMpSpellEffect(int potency, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RestoreSpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RestoreSpSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record RestoreSpSpellEffect(int potency, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/RestoreSpSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/RestoreSpSpellEffect.java
@@ -1,2 +1,8 @@
 package legend.game.combat.spells;
+/**
+ * Restores SP to each matched player target, up to that target's maximum SP.
+ *
+ * @param potency flat SP restored, or percent of maximum SP when {@code percentage} is true
+ * @param percentage whether {@code potency} is a percentage of the target's maximum SP
+ */
 public record RestoreSpSpellEffect(int potency, boolean percentage) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/ReviveSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/ReviveSpellEffect.java
@@ -1,2 +1,8 @@
 package legend.game.combat.spells;
+/**
+ * Revives each matched dead target before other restoration effects are applied.
+ *
+ * @param hpPercent percent of maximum HP restored on revival; revival always restores at least
+ *                  one HP
+ */
 public record ReviveSpellEffect(int hpPercent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/ReviveSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/ReviveSpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public record ReviveSpellEffect(int hpPercent) implements SpellEffect { }

--- a/src/main/java/legend/game/combat/spells/SpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffect.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public sealed interface SpellEffect permits DamageSpellEffect, HealHpSpellEffect, RestoreMpSpellEffect, RestoreSpSpellEffect, ReviveSpellEffect, CleanseSpellEffect, DrainHpSpellEffect, DrainMpSpellEffect, DrainSpSpellEffect, ApplyStatusSpellEffect, StatModifierSpellEffect, RegenHpSpellEffect, RegenMpSpellEffect, RegenSpSpellEffect { }

--- a/src/main/java/legend/game/combat/spells/SpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffect.java
@@ -1,2 +1,9 @@
 package legend.game.combat.spells;
+/**
+ * Describes one immutable operation in a declarative {@link SpellEffectPlan}.
+ *
+ * <p>Mod listeners may compose the permitted effect records into a plan and return that plan
+ * through a spell-stats replacement. Effects are interpreted only when the plan uses
+ * {@link ExecutionMode#DECLARATIVE}.</p>
+ */
 public sealed interface SpellEffect permits DamageSpellEffect, HealHpSpellEffect, RestoreMpSpellEffect, RestoreSpSpellEffect, ReviveSpellEffect, CleanseSpellEffect, DrainHpSpellEffect, DrainMpSpellEffect, DrainSpSpellEffect, ApplyStatusSpellEffect, StatModifierSpellEffect, RegenHpSpellEffect, RegenMpSpellEffect, RegenSpSpellEffect { }

--- a/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
@@ -14,8 +14,27 @@ import java.util.Random;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
+/**
+ * Resolves and applies {@link ExecutionMode#DECLARATIVE declarative} spell-effect plans.
+ *
+ * <p>Mod consumers normally construct {@link SpellEffectPlan} values and attach them to spell
+ * stats; the battle runtime invokes this executor when that spell is cast.</p>
+ */
 public final class SpellEffectExecutor {
-  public List<TargetedSpellEffects> prepare(final PlayerBattleEntity caster, final BattleEntity27c selectedTarget, final List<? extends BattleEntity27c> battleEntities, final List<SpellEffectPlan> plans, final DamageCalculator damageCalculator) {
+    /**
+     * Resolves the eligible targets and damage for every declarative plan in one cast.
+     *
+     * <p>Plans using a different execution mode are ignored. The returned list is immutable and
+     * contains one entry for each matched target and plan.</p>
+     *
+     * @param caster player casting the spell
+     * @param selectedTarget target selected for the cast
+     * @param battleEntities entities available for target matching
+     * @param plans effect plans attached to the active spell
+     * @param damageCalculator callback that calculates damage for a target and combined power
+     * @return immutable prepared target/effect entries for declarative plans
+     */
+    public List<TargetedSpellEffects> prepare(final PlayerBattleEntity caster, final BattleEntity27c selectedTarget, final List<? extends BattleEntity27c> battleEntities, final List<SpellEffectPlan> plans, final DamageCalculator damageCalculator) {
     final List<TargetedSpellEffects> prepared = new ArrayList<>();
     for(final SpellEffectPlan plan : plans) {
       if(plan.executionMode() != ExecutionMode.DECLARATIVE) {
@@ -53,7 +72,17 @@ public final class SpellEffectExecutor {
     return List.of();
   }
 
-  public int complete(final PlayerBattleEntity caster, final BattleEntity27c target, final PreparedSpellEffects prepared, final Random random, final int appliedVitalLoss) {
+    /**
+     * Applies one prepared plan after its damage result is known.
+     *
+     * @param caster player casting the spell
+     * @param target target receiving this plan's effects
+     * @param prepared plan and non-negative prepared damage for the target
+     * @param random random source used for status-chance rolls
+     * @param appliedVitalLoss HP loss actually applied to the target, used by drain effects
+     * @return selected status bit when a status roll succeeds, otherwise {@code -1}
+     */
+    public int complete(final PlayerBattleEntity caster, final BattleEntity27c target, final PreparedSpellEffects prepared, final Random random, final int appliedVitalLoss) {
     final int targetHp = target.stats.getStat(LodMod.HP_STAT.get()).getCurrent();
     final boolean targetWasDead = targetHp == 0;
     final int vitalLoss = min(max(0, appliedVitalLoss), targetHp);
@@ -161,7 +190,13 @@ public final class SpellEffectExecutor {
     return validLifeState;
   }
 
-  public record TargetedSpellEffects(BattleEntity27c target, PreparedSpellEffects effects) {
+    /**
+     * Associates one matched target with the effects prepared for it.
+     *
+     * @param target matched battle entity
+     * @param effects plan and damage prepared for that target
+     */
+    public record TargetedSpellEffects(BattleEntity27c target, PreparedSpellEffects effects) {
     public TargetedSpellEffects {
       if(target == null) {
         throw new IllegalArgumentException("Prepared spell target cannot be null");
@@ -181,14 +216,26 @@ public final class SpellEffectExecutor {
     STATUS,
     STAT_MODIFIER,
     REGEN,
-  }
+    }
 
-  @FunctionalInterface
-  public interface DamageCalculator {
-    int calculate(BattleEntity27c target, int power);
-  }
+    /** Calculates spell damage for one target and combined declarative power. */
+    @FunctionalInterface
+    public interface DamageCalculator {
+        /**
+         * @param target target whose damage is being calculated
+         * @param power sum of all {@link DamageSpellEffect#power()} values in the plan
+         * @return calculated damage before the plan is completed
+         */
+        int calculate(BattleEntity27c target, int power);
+    }
 
-  public record PreparedSpellEffects(SpellEffectPlan plan, int damage) {
+    /**
+     * Immutable plan data prepared for one target before effects are applied.
+     *
+     * @param plan declarative plan being applied
+     * @param damage non-negative calculated damage for the target
+     */
+    public record PreparedSpellEffects(SpellEffectPlan plan, int damage) {
     public PreparedSpellEffects {
       if(plan == null) {
         throw new IllegalArgumentException("Prepared spell effect plan cannot be null");
@@ -198,28 +245,53 @@ public final class SpellEffectExecutor {
         throw new IllegalArgumentException("Prepared spell damage cannot be negative");
       }
     }
-  }
+    }
 
-  public static final class RegenState {
-    public final Regen hp = new Regen();
-    public final Regen mp = new Regen();
-    public final Regen sp = new Regen();
+    /** Holds the replaceable HP, MP, and SP regeneration currently active on one battle entity. */
+    public static final class RegenState {
+        /** Current HP regeneration. */
+        public final Regen hp = new Regen();
 
-    public void turnFinished(final BattleEntity27c target) {
+        /** Current MP regeneration. */
+        public final Regen mp = new Regen();
+
+        /** Current SP regeneration. */
+        public final Regen sp = new Regen();
+
+        /**
+         * Applies one regeneration tick after the target completes a turn.
+         *
+         * <p>All targets receive HP regeneration; only player targets receive MP and SP
+         * regeneration.</p>
+         *
+         * @param target battle entity whose turn completed
+         */
+        public void turnFinished(final BattleEntity27c target) {
       this.hp.tick(target, LodMod.HP_STAT.get());
       if(target instanceof PlayerBattleEntity) {
         this.mp.tick(target, LodMod.MP_STAT.get());
         this.sp.tick(target, LodMod.SP_STAT.get());
       }
     }
-  }
+    }
 
-  public static final class Regen {
+    /** Mutable state for one renewable vital, replaced when a new regeneration effect is applied. */
+    public static final class Regen {
     private int potency;
     private int turns;
     private boolean percentage;
 
-    public void set(final int potency, final int turns, final boolean percentage) {
+        /**
+         * Replaces the active regeneration values.
+         *
+         * <p>Negative potency and turn values are stored as zero.</p>
+         *
+         * @param potency flat amount restored per turn, or percent of the maximum when
+         *                {@code percentage} is true
+         * @param turns number of remaining turn-completion ticks
+         * @param percentage whether {@code potency} is a percentage of the vital's maximum
+         */
+        public void set(final int potency, final int turns, final boolean percentage) {
       this.potency = max(0, potency);
       this.turns = max(0, turns);
       this.percentage = percentage;

--- a/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
@@ -9,15 +9,37 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
-import java.util.function.IntUnaryOperator;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 public final class SpellEffectExecutor {
-  public PreparedSpellEffects prepare(final PlayerBattleEntity caster, final BattleEntity27c target, final SpellEffectPlan plan, final IntUnaryOperator damageCalculator) {
-    this.validateTarget(caster, target, plan.target());
+  public List<TargetedSpellEffects> prepare(final PlayerBattleEntity caster, final BattleEntity27c selectedTarget, final List<? extends BattleEntity27c> battleEntities, final List<SpellEffectPlan> plans, final DamageCalculator damageCalculator) {
+    final List<TargetedSpellEffects> prepared = new ArrayList<>();
+    for(final SpellEffectPlan plan : plans) {
+      if(plan.executionMode() != ExecutionMode.DECLARATIVE) {
+        continue;
+      }
 
+      if(plan.target().scope() == TargetScope.SINGLE) {
+        final BattleEntity27c target = this.singleTarget(caster, selectedTarget, battleEntities, plan.target());
+        if(target != null) {
+          prepared.add(new TargetedSpellEffects(target, this.prepare(target, plan, damageCalculator)));
+        }
+        continue;
+      }
+
+      for(final BattleEntity27c target : battleEntities) {
+        if(this.matchesTarget(caster, target, plan.target())) {
+          prepared.add(new TargetedSpellEffects(target, this.prepare(target, plan, damageCalculator)));
+        }
+      }
+    }
+
+    return List.copyOf(prepared);
+  }
+
+  private PreparedSpellEffects prepare(final BattleEntity27c target, final SpellEffectPlan plan, final DamageCalculator damageCalculator) {
     int damagePower = 0;
     for(final SpellEffect effect : plan.effects()) {
       if(effect instanceof DamageSpellEffect damageEffect) {
@@ -25,8 +47,22 @@ public final class SpellEffectExecutor {
       }
     }
 
-    final int damage = damagePower == 0 ? 0 : damageCalculator.applyAsInt(damagePower);
+    final int damage = damagePower == 0 ? 0 : damageCalculator.calculate(target, damagePower);
     return new PreparedSpellEffects(plan, max(0, damage));
+  }
+
+  private BattleEntity27c singleTarget(final PlayerBattleEntity caster, final BattleEntity27c selectedTarget, final List<? extends BattleEntity27c> battleEntities, final SpellTargetProfile profile) {
+    if(this.matchesTarget(caster, selectedTarget, profile)) {
+      return selectedTarget;
+    }
+
+    for(final BattleEntity27c target : battleEntities) {
+      if(this.matchesTarget(caster, target, profile)) {
+        return target;
+      }
+    }
+
+    return null;
   }
 
   public int complete(final PlayerBattleEntity caster, final BattleEntity27c target, final PreparedSpellEffects prepared, final Random random, final int appliedVitalLoss) {
@@ -124,7 +160,7 @@ public final class SpellEffectExecutor {
     }
   }
 
-  private void validateTarget(final PlayerBattleEntity caster, final BattleEntity27c target, final SpellTargetProfile profile) {
+  private boolean matchesTarget(final PlayerBattleEntity caster, final BattleEntity27c target, final SpellTargetProfile profile) {
     final boolean targetIsPlayer = target instanceof PlayerBattleEntity;
     final boolean validSide = switch(profile.side()) {
       case SELF -> target == caster;
@@ -133,7 +169,7 @@ public final class SpellEffectExecutor {
       case ANY -> true;
     };
     if(!validSide) {
-      throw new IllegalArgumentException("Spell target " + target + " is incompatible with target side " + profile.side());
+      return false;
     }
 
     final boolean targetIsLiving = target.stats.getStat(LodMod.HP_STAT.get()).getCurrent() > 0;
@@ -142,8 +178,17 @@ public final class SpellEffectExecutor {
       case DEAD -> !targetIsLiving;
       case ANY -> true;
     };
-    if(!validLifeState) {
-      throw new IllegalArgumentException("Spell target " + target + " is incompatible with target life state " + profile.lifeState());
+    return validLifeState;
+  }
+
+  public record TargetedSpellEffects(BattleEntity27c target, PreparedSpellEffects effects) {
+    public TargetedSpellEffects {
+      if(target == null) {
+        throw new IllegalArgumentException("Prepared spell target cannot be null");
+      }
+      if(effects == null) {
+        throw new IllegalArgumentException("Prepared spell effects cannot be null");
+      }
     }
   }
 
@@ -156,6 +201,11 @@ public final class SpellEffectExecutor {
     STATUS,
     STAT_MODIFIER,
     REGEN,
+  }
+
+  @FunctionalInterface
+  public interface DamageCalculator {
+    int calculate(BattleEntity27c target, int power);
   }
 
   public record PreparedSpellEffects(SpellEffectPlan plan, int damage) {

--- a/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
@@ -1,5 +1,6 @@
 package legend.game.combat.spells;
 
+import legend.game.characters.StatType;
 import legend.game.characters.VitalsStat;
 import legend.game.combat.bent.BattleEntity27c;
 import legend.game.combat.bent.PlayerBattleEntity;
@@ -21,88 +22,77 @@ public final class SpellEffectExecutor {
         continue;
       }
 
-      if(plan.target().scope() == TargetScope.SINGLE) {
-        final BattleEntity27c target = this.singleTarget(caster, selectedTarget, battleEntities, plan.target());
-        if(target != null) {
-          prepared.add(new TargetedSpellEffects(target, this.prepare(target, plan, damageCalculator)));
-        }
-        continue;
-      }
-
-      for(final BattleEntity27c target : battleEntities) {
-        if(this.matchesTarget(caster, target, plan.target())) {
-          prepared.add(new TargetedSpellEffects(target, this.prepare(target, plan, damageCalculator)));
-        }
+      for(final BattleEntity27c target : this.targets(caster, selectedTarget, battleEntities, plan.target())) {
+        prepared.add(new TargetedSpellEffects(target, this.prepareTarget(target, plan, damageCalculator)));
       }
     }
 
     return List.copyOf(prepared);
   }
 
-  private PreparedSpellEffects prepare(final BattleEntity27c target, final SpellEffectPlan plan, final DamageCalculator damageCalculator) {
-    int damagePower = 0;
-    for(final SpellEffect effect : plan.effects()) {
-      if(effect instanceof DamageSpellEffect damageEffect) {
-        damagePower += damageEffect.power();
-      }
-    }
-
+  private PreparedSpellEffects prepareTarget(final BattleEntity27c target, final SpellEffectPlan plan, final DamageCalculator damageCalculator) {
+    final int damagePower = plan.effects().stream().mapToInt(effect -> effect instanceof DamageSpellEffect damage ? damage.power() : 0).sum();
     final int damage = damagePower == 0 ? 0 : damageCalculator.calculate(target, damagePower);
     return new PreparedSpellEffects(plan, max(0, damage));
   }
 
-  private BattleEntity27c singleTarget(final PlayerBattleEntity caster, final BattleEntity27c selectedTarget, final List<? extends BattleEntity27c> battleEntities, final SpellTargetProfile profile) {
-    if(this.matchesTarget(caster, selectedTarget, profile)) {
-      return selectedTarget;
+  private List<? extends BattleEntity27c> targets(final PlayerBattleEntity caster, final BattleEntity27c selectedTarget, final List<? extends BattleEntity27c> battleEntities, final SpellTargetProfile profile) {
+    if(profile.scope() == TargetScope.ALL) {
+      return battleEntities.stream().filter(target -> this.matchesTarget(caster, target, profile)).toList();
     }
 
+    if(this.matchesTarget(caster, selectedTarget, profile)) {
+      return List.of(selectedTarget);
+    }
     for(final BattleEntity27c target : battleEntities) {
       if(this.matchesTarget(caster, target, profile)) {
-        return target;
+        return List.of(target);
       }
     }
 
-    return null;
+    return List.of();
   }
 
   public int complete(final PlayerBattleEntity caster, final BattleEntity27c target, final PreparedSpellEffects prepared, final Random random, final int appliedVitalLoss) {
-    final SpellEffectPlan plan = prepared.plan();
-    final boolean targetWasDead = target.stats.getStat(LodMod.HP_STAT.get()).getCurrent() == 0;
-    final List<SpellEffect> effects = new ArrayList<>(plan.effects());
-    effects.sort(Comparator.comparing(this::effectPhase));
-    final int vitalLoss = min(max(0, appliedVitalLoss), target.stats.getStat(LodMod.HP_STAT.get()).getCurrent());
+    final int targetHp = target.stats.getStat(LodMod.HP_STAT.get()).getCurrent();
+    final boolean targetWasDead = targetHp == 0;
+    final int vitalLoss = min(max(0, appliedVitalLoss), targetHp);
+    final List<SpellEffect> effects = prepared.plan().effects().stream().sorted(Comparator.comparing(this::effectPhase)).toList();
     int statusEffect = -1;
 
     for(final SpellEffect effect : effects) {
-      if(effect instanceof ReviveSpellEffect revive) {
-        this.revive(target, revive);
-      } else if(effect instanceof CleanseSpellEffect cleanse) {
-        target.status_0e &= ~cleanse.statusMask();
-      } else if(effect instanceof HealHpSpellEffect heal) {
-        // Retail revive/recovery packages revive dead targets and recover living targets.
-        if(!targetWasDead) {
-          this.restore(target, LodMod.HP_STAT.get(), heal.potency(), heal.percentage());
+      switch(effect) {
+        case ReviveSpellEffect revive -> this.revive(target, revive);
+        case CleanseSpellEffect cleanse -> target.status_0e &= ~cleanse.statusMask();
+        case HealHpSpellEffect heal -> {
+          // Retail revive/recovery packages revive dead targets and recover living targets.
+          if(!targetWasDead) {
+            this.restore(target, LodMod.HP_STAT.get(), heal.potency(), heal.percentage());
+          }
         }
-      } else if(effect instanceof RestoreMpSpellEffect restore && target instanceof PlayerBattleEntity) {
-        this.restore(target, LodMod.MP_STAT.get(), restore.potency(), restore.percentage());
-      } else if(effect instanceof RestoreSpSpellEffect restore && target instanceof PlayerBattleEntity) {
-        this.restore(target, LodMod.SP_STAT.get(), restore.potency(), restore.percentage());
-      } else if(effect instanceof DrainHpSpellEffect drain) {
-        this.restore(caster, LodMod.HP_STAT.get(), vitalLoss * drain.percent() / 100, false);
-      } else if(effect instanceof DrainMpSpellEffect drain) {
-        this.restore(caster, LodMod.MP_STAT.get(), vitalLoss * drain.percent() / 100, false);
-      } else if(effect instanceof DrainSpSpellEffect drain) {
-        this.restore(caster, LodMod.SP_STAT.get(), vitalLoss * drain.percent() / 100, false);
-      } else if(effect instanceof ApplyStatusSpellEffect status && statusEffect == -1 && random.nextInt(100) < status.chance()) {
-        statusEffect = Integer.highestOneBit(status.statusMask() & 0xff);
-      } else if(effect instanceof StatModifierSpellEffect modifier) {
-        this.applyStatModifier(target, modifier);
-      } else if(effect instanceof RegenHpSpellEffect regen) {
-        target.spellRegen.hp.set(regen.potency(), regen.turns(), regen.percentage());
-      } else if(effect instanceof RegenMpSpellEffect regen) {
-        target.spellRegen.mp.set(regen.potency(), regen.turns(), regen.percentage());
-      } else if(effect instanceof RegenSpSpellEffect regen) {
-        target.spellRegen.sp.set(regen.potency(), regen.turns(), regen.percentage());
+        case RestoreMpSpellEffect restore -> {
+          if(target instanceof PlayerBattleEntity) {
+            this.restore(target, LodMod.MP_STAT.get(), restore.potency(), restore.percentage());
+          }
+        }
+        case RestoreSpSpellEffect restore -> {
+          if(target instanceof PlayerBattleEntity) {
+            this.restore(target, LodMod.SP_STAT.get(), restore.potency(), restore.percentage());
+          }
+        }
+        case DamageSpellEffect ignored -> { }
+        case DrainHpSpellEffect drain -> this.restore(caster, LodMod.HP_STAT.get(), vitalLoss * drain.percent() / 100, false);
+        case DrainMpSpellEffect drain -> this.restore(caster, LodMod.MP_STAT.get(), vitalLoss * drain.percent() / 100, false);
+        case DrainSpSpellEffect drain -> this.restore(caster, LodMod.SP_STAT.get(), vitalLoss * drain.percent() / 100, false);
+        case ApplyStatusSpellEffect status -> {
+          if(statusEffect == -1 && random.nextInt(100) < status.chance()) {
+            statusEffect = Integer.highestOneBit(status.statusMask() & 0xff);
+          }
+        }
+        case StatModifierSpellEffect modifier -> this.applyStatModifier(target, modifier);
+        case RegenHpSpellEffect regen -> target.spellRegen.hp.set(regen.potency(), regen.turns(), regen.percentage());
+        case RegenMpSpellEffect regen -> target.spellRegen.mp.set(regen.potency(), regen.turns(), regen.percentage());
+        case RegenSpSpellEffect regen -> target.spellRegen.sp.set(regen.potency(), regen.turns(), regen.percentage());
       }
     }
 
@@ -110,32 +100,22 @@ public final class SpellEffectExecutor {
   }
 
   private EffectPhase effectPhase(final SpellEffect effect) {
-    if(effect instanceof ReviveSpellEffect) {
-      return EffectPhase.REVIVE;
-    }
-    if(effect instanceof CleanseSpellEffect) {
-      return EffectPhase.CLEANSE;
-    }
-    if(effect instanceof HealHpSpellEffect || effect instanceof RestoreMpSpellEffect || effect instanceof RestoreSpSpellEffect) {
-      return EffectPhase.RESTORE;
-    }
-    if(effect instanceof DamageSpellEffect) {
-      return EffectPhase.DAMAGE;
-    }
-    if(effect instanceof DrainHpSpellEffect || effect instanceof DrainMpSpellEffect || effect instanceof DrainSpSpellEffect) {
-      return EffectPhase.DRAIN;
-    }
-    if(effect instanceof ApplyStatusSpellEffect) {
-      return EffectPhase.STATUS;
-    }
-    if(effect instanceof StatModifierSpellEffect) {
-      return EffectPhase.STAT_MODIFIER;
-    }
-    if(effect instanceof RegenHpSpellEffect || effect instanceof RegenMpSpellEffect || effect instanceof RegenSpSpellEffect) {
-      return EffectPhase.REGEN;
-    }
-
-    throw new IllegalArgumentException("Unsupported spell effect " + effect.getClass().getName());
+    return switch(effect) {
+      case ReviveSpellEffect ignored -> EffectPhase.REVIVE;
+      case CleanseSpellEffect ignored -> EffectPhase.CLEANSE;
+      case HealHpSpellEffect ignored -> EffectPhase.RESTORE;
+      case RestoreMpSpellEffect ignored -> EffectPhase.RESTORE;
+      case RestoreSpSpellEffect ignored -> EffectPhase.RESTORE;
+      case DamageSpellEffect ignored -> EffectPhase.DAMAGE;
+      case DrainHpSpellEffect ignored -> EffectPhase.DRAIN;
+      case DrainMpSpellEffect ignored -> EffectPhase.DRAIN;
+      case DrainSpSpellEffect ignored -> EffectPhase.DRAIN;
+      case ApplyStatusSpellEffect ignored -> EffectPhase.STATUS;
+      case StatModifierSpellEffect ignored -> EffectPhase.STAT_MODIFIER;
+      case RegenHpSpellEffect ignored -> EffectPhase.REGEN;
+      case RegenMpSpellEffect ignored -> EffectPhase.REGEN;
+      case RegenSpSpellEffect ignored -> EffectPhase.REGEN;
+    };
   }
 
   private void revive(final BattleEntity27c target, final ReviveSpellEffect revive) {
@@ -145,8 +125,8 @@ public final class SpellEffectExecutor {
     }
   }
 
-  private void restore(final BattleEntity27c target, final Object statType, final int potency, final boolean percentage) {
-    @SuppressWarnings("unchecked") final VitalsStat stat = target.stats.getStat((legend.game.characters.StatType<VitalsStat>)statType);
+  private void restore(final BattleEntity27c target, final StatType<VitalsStat> statType, final int potency, final boolean percentage) {
+    final VitalsStat stat = target.stats.getStat(statType);
     final int amount = percentage ? stat.getMax() * potency / 100 : potency;
     stat.setCurrent(min(stat.getMax(), stat.getCurrent() + max(0, amount)));
   }
@@ -245,12 +225,12 @@ public final class SpellEffectExecutor {
       this.percentage = percentage;
     }
 
-    private void tick(final BattleEntity27c target, final Object statType) {
+    private void tick(final BattleEntity27c target, final StatType<VitalsStat> statType) {
       if(this.turns == 0) {
         return;
       }
 
-      @SuppressWarnings("unchecked") final VitalsStat stat = target.stats.getStat((legend.game.characters.StatType<VitalsStat>)statType);
+      final VitalsStat stat = target.stats.getStat(statType);
       final int amount = this.percentage ? stat.getMax() * this.potency / 100 : this.potency;
       stat.setCurrent(min(stat.getMax(), stat.getCurrent() + amount));
       this.turns--;

--- a/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffectExecutor.java
@@ -1,0 +1,209 @@
+package legend.game.combat.spells;
+
+import legend.game.characters.VitalsStat;
+import legend.game.combat.bent.BattleEntity27c;
+import legend.game.combat.bent.PlayerBattleEntity;
+import legend.lodmod.LodMod;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntUnaryOperator;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+public final class SpellEffectExecutor {
+  public PreparedSpellEffects prepare(final PlayerBattleEntity caster, final BattleEntity27c target, final SpellEffectPlan plan, final IntUnaryOperator damageCalculator) {
+    this.validateTarget(caster, target, plan.target());
+
+    int damagePower = 0;
+    for(final SpellEffect effect : plan.effects()) {
+      if(effect instanceof DamageSpellEffect damageEffect) {
+        damagePower += damageEffect.power();
+      }
+    }
+
+    final int damage = damagePower == 0 ? 0 : damageCalculator.applyAsInt(damagePower);
+    return new PreparedSpellEffects(plan, max(0, damage));
+  }
+
+  public int complete(final PlayerBattleEntity caster, final BattleEntity27c target, final PreparedSpellEffects prepared, final Random random, final int appliedVitalLoss) {
+    final SpellEffectPlan plan = prepared.plan();
+    final boolean targetWasDead = target.stats.getStat(LodMod.HP_STAT.get()).getCurrent() == 0;
+    final List<SpellEffect> effects = new ArrayList<>(plan.effects());
+    effects.sort(Comparator.comparing(this::effectPhase));
+    final int vitalLoss = min(max(0, appliedVitalLoss), target.stats.getStat(LodMod.HP_STAT.get()).getCurrent());
+    int statusEffect = -1;
+
+    for(final SpellEffect effect : effects) {
+      if(effect instanceof ReviveSpellEffect revive) {
+        this.revive(target, revive);
+      } else if(effect instanceof CleanseSpellEffect cleanse) {
+        target.status_0e &= ~cleanse.statusMask();
+      } else if(effect instanceof HealHpSpellEffect heal) {
+        // Retail revive/recovery packages revive dead targets and recover living targets.
+        if(!targetWasDead) {
+          this.restore(target, LodMod.HP_STAT.get(), heal.potency(), heal.percentage());
+        }
+      } else if(effect instanceof RestoreMpSpellEffect restore && target instanceof PlayerBattleEntity) {
+        this.restore(target, LodMod.MP_STAT.get(), restore.potency(), restore.percentage());
+      } else if(effect instanceof RestoreSpSpellEffect restore && target instanceof PlayerBattleEntity) {
+        this.restore(target, LodMod.SP_STAT.get(), restore.potency(), restore.percentage());
+      } else if(effect instanceof DrainHpSpellEffect drain) {
+        this.restore(caster, LodMod.HP_STAT.get(), vitalLoss * drain.percent() / 100, false);
+      } else if(effect instanceof DrainMpSpellEffect drain) {
+        this.restore(caster, LodMod.MP_STAT.get(), vitalLoss * drain.percent() / 100, false);
+      } else if(effect instanceof DrainSpSpellEffect drain) {
+        this.restore(caster, LodMod.SP_STAT.get(), vitalLoss * drain.percent() / 100, false);
+      } else if(effect instanceof ApplyStatusSpellEffect status && statusEffect == -1 && random.nextInt(100) < status.chance()) {
+        statusEffect = Integer.highestOneBit(status.statusMask() & 0xff);
+      } else if(effect instanceof StatModifierSpellEffect modifier) {
+        this.applyStatModifier(target, modifier);
+      } else if(effect instanceof RegenHpSpellEffect regen) {
+        target.spellRegen.hp.set(regen.potency(), regen.turns(), regen.percentage());
+      } else if(effect instanceof RegenMpSpellEffect regen) {
+        target.spellRegen.mp.set(regen.potency(), regen.turns(), regen.percentage());
+      } else if(effect instanceof RegenSpSpellEffect regen) {
+        target.spellRegen.sp.set(regen.potency(), regen.turns(), regen.percentage());
+      }
+    }
+
+    return statusEffect;
+  }
+
+  private EffectPhase effectPhase(final SpellEffect effect) {
+    if(effect instanceof ReviveSpellEffect) {
+      return EffectPhase.REVIVE;
+    }
+    if(effect instanceof CleanseSpellEffect) {
+      return EffectPhase.CLEANSE;
+    }
+    if(effect instanceof HealHpSpellEffect || effect instanceof RestoreMpSpellEffect || effect instanceof RestoreSpSpellEffect) {
+      return EffectPhase.RESTORE;
+    }
+    if(effect instanceof DamageSpellEffect) {
+      return EffectPhase.DAMAGE;
+    }
+    if(effect instanceof DrainHpSpellEffect || effect instanceof DrainMpSpellEffect || effect instanceof DrainSpSpellEffect) {
+      return EffectPhase.DRAIN;
+    }
+    if(effect instanceof ApplyStatusSpellEffect) {
+      return EffectPhase.STATUS;
+    }
+    if(effect instanceof StatModifierSpellEffect) {
+      return EffectPhase.STAT_MODIFIER;
+    }
+    if(effect instanceof RegenHpSpellEffect || effect instanceof RegenMpSpellEffect || effect instanceof RegenSpSpellEffect) {
+      return EffectPhase.REGEN;
+    }
+
+    throw new IllegalArgumentException("Unsupported spell effect " + effect.getClass().getName());
+  }
+
+  private void revive(final BattleEntity27c target, final ReviveSpellEffect revive) {
+    final VitalsStat hp = target.stats.getStat(LodMod.HP_STAT.get());
+    if(hp.getCurrent() == 0) {
+      hp.setCurrent(max(1, hp.getMax() * revive.hpPercent() / 100));
+    }
+  }
+
+  private void restore(final BattleEntity27c target, final Object statType, final int potency, final boolean percentage) {
+    @SuppressWarnings("unchecked") final VitalsStat stat = target.stats.getStat((legend.game.characters.StatType<VitalsStat>)statType);
+    final int amount = percentage ? stat.getMax() * potency / 100 : potency;
+    stat.setCurrent(min(stat.getMax(), stat.getCurrent() + max(0, amount)));
+  }
+
+  private void applyStatModifier(final BattleEntity27c target, final StatModifierSpellEffect modifier) {
+    switch(modifier.stat()) {
+      case ATTACK -> { target.powerAttack_b4 = modifier.amount(); target.powerAttackTurns_b5 = modifier.turns(); }
+      case MAGIC_ATTACK -> { target.powerMagicAttack_b6 = modifier.amount(); target.powerMagicAttackTurns_b7 = modifier.turns(); }
+      case DEFENCE -> { target.powerDefence_b8 = modifier.amount(); target.powerDefenceTurns_b9 = modifier.turns(); }
+      case MAGIC_DEFENCE -> { target.powerMagicDefence_ba = modifier.amount(); target.powerMagicDefenceTurns_bb = modifier.turns(); }
+    }
+  }
+
+  private void validateTarget(final PlayerBattleEntity caster, final BattleEntity27c target, final SpellTargetProfile profile) {
+    final boolean targetIsPlayer = target instanceof PlayerBattleEntity;
+    final boolean validSide = switch(profile.side()) {
+      case SELF -> target == caster;
+      case ALLIES -> targetIsPlayer;
+      case ENEMIES -> !targetIsPlayer;
+      case ANY -> true;
+    };
+    if(!validSide) {
+      throw new IllegalArgumentException("Spell target " + target + " is incompatible with target side " + profile.side());
+    }
+
+    final boolean targetIsLiving = target.stats.getStat(LodMod.HP_STAT.get()).getCurrent() > 0;
+    final boolean validLifeState = switch(profile.lifeState()) {
+      case LIVING -> targetIsLiving;
+      case DEAD -> !targetIsLiving;
+      case ANY -> true;
+    };
+    if(!validLifeState) {
+      throw new IllegalArgumentException("Spell target " + target + " is incompatible with target life state " + profile.lifeState());
+    }
+  }
+
+  private enum EffectPhase {
+    REVIVE,
+    CLEANSE,
+    RESTORE,
+    DAMAGE,
+    DRAIN,
+    STATUS,
+    STAT_MODIFIER,
+    REGEN,
+  }
+
+  public record PreparedSpellEffects(SpellEffectPlan plan, int damage) {
+    public PreparedSpellEffects {
+      if(plan == null) {
+        throw new IllegalArgumentException("Prepared spell effect plan cannot be null");
+      }
+
+      if(damage < 0) {
+        throw new IllegalArgumentException("Prepared spell damage cannot be negative");
+      }
+    }
+  }
+
+  public static final class RegenState {
+    public final Regen hp = new Regen();
+    public final Regen mp = new Regen();
+    public final Regen sp = new Regen();
+
+    public void turnFinished(final BattleEntity27c target) {
+      this.hp.tick(target, LodMod.HP_STAT.get());
+      if(target instanceof PlayerBattleEntity) {
+        this.mp.tick(target, LodMod.MP_STAT.get());
+        this.sp.tick(target, LodMod.SP_STAT.get());
+      }
+    }
+  }
+
+  public static final class Regen {
+    private int potency;
+    private int turns;
+    private boolean percentage;
+
+    public void set(final int potency, final int turns, final boolean percentage) {
+      this.potency = max(0, potency);
+      this.turns = max(0, turns);
+      this.percentage = percentage;
+    }
+
+    private void tick(final BattleEntity27c target, final Object statType) {
+      if(this.turns == 0) {
+        return;
+      }
+
+      @SuppressWarnings("unchecked") final VitalsStat stat = target.stats.getStat((legend.game.characters.StatType<VitalsStat>)statType);
+      final int amount = this.percentage ? stat.getMax() * this.potency / 100 : this.potency;
+      stat.setCurrent(min(stat.getMax(), stat.getCurrent() + amount));
+      this.turns--;
+    }
+  }
+}

--- a/src/main/java/legend/game/combat/spells/SpellEffectPlan.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffectPlan.java
@@ -2,6 +2,17 @@ package legend.game.combat.spells;
 
 import java.util.List;
 
+/**
+ * Immutable targeting, effects, and execution policy for one part of a spell cast.
+ *
+ * <p>A spell may contain multiple plans so different effects can target different groups. The
+ * constructor defensively copies {@code effects}; changing the source list afterward does not
+ * change this plan.</p>
+ *
+ * @param target rules used to select battle entities for this plan
+ * @param effects immutable effect declarations applied to every matched target
+ * @param executionMode runtime responsible for interpreting this plan
+ */
 public record SpellEffectPlan(SpellTargetProfile target, List<SpellEffect> effects, ExecutionMode executionMode) {
   private static final SpellEffectPlan LEGACY = new SpellEffectPlan(new SpellTargetProfile(TargetSide.ANY, TargetScope.SINGLE, TargetLifeState.ANY), List.of(), ExecutionMode.LEGACY);
 
@@ -27,7 +38,12 @@ public record SpellEffectPlan(SpellTargetProfile target, List<SpellEffect> effec
     effects = List.copyOf(effects);
   }
 
-  public static SpellEffectPlan legacy() {
+    /**
+     * Returns the shared plan that delegates entirely to retail spell fields and scripts.
+     *
+     * @return an immutable legacy plan with no declarative effects
+     */
+    public static SpellEffectPlan legacy() {
     return LEGACY;
   }
 }

--- a/src/main/java/legend/game/combat/spells/SpellEffectPlan.java
+++ b/src/main/java/legend/game/combat/spells/SpellEffectPlan.java
@@ -1,0 +1,33 @@
+package legend.game.combat.spells;
+
+import java.util.List;
+
+public record SpellEffectPlan(SpellTargetProfile target, List<SpellEffect> effects, ExecutionMode executionMode) {
+  private static final SpellEffectPlan LEGACY = new SpellEffectPlan(new SpellTargetProfile(TargetSide.ANY, TargetScope.SINGLE, TargetLifeState.ANY), List.of(), ExecutionMode.LEGACY);
+
+  public SpellEffectPlan {
+    if(target == null) {
+      throw new IllegalArgumentException("Spell effect target cannot be null");
+    }
+
+    if(effects == null) {
+      throw new IllegalArgumentException("Spell effects cannot be null");
+    }
+
+    for(final SpellEffect effect : effects) {
+      if(effect == null) {
+        throw new IllegalArgumentException("Spell effects cannot contain null entries");
+      }
+    }
+
+    if(executionMode == null) {
+      throw new IllegalArgumentException("Spell execution mode cannot be null");
+    }
+
+    effects = List.copyOf(effects);
+  }
+
+  public static SpellEffectPlan legacy() {
+    return LEGACY;
+  }
+}

--- a/src/main/java/legend/game/combat/spells/SpellStat.java
+++ b/src/main/java/legend/game/combat/spells/SpellStat.java
@@ -1,2 +1,15 @@
 package legend.game.combat.spells;
-public enum SpellStat { ATTACK, MAGIC_ATTACK, DEFENCE, MAGIC_DEFENCE }
+/** Identifies a battle stat modified by {@link StatModifierSpellEffect}. */
+public enum SpellStat {
+    /** Physical attack. */
+    ATTACK,
+
+    /** Magical attack. */
+    MAGIC_ATTACK,
+
+    /** Physical defence. */
+    DEFENCE,
+
+    /** Magical defence. */
+    MAGIC_DEFENCE,
+}

--- a/src/main/java/legend/game/combat/spells/SpellStat.java
+++ b/src/main/java/legend/game/combat/spells/SpellStat.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public enum SpellStat { ATTACK, MAGIC_ATTACK, DEFENCE, MAGIC_DEFENCE }

--- a/src/main/java/legend/game/combat/spells/SpellTargetProfile.java
+++ b/src/main/java/legend/game/combat/spells/SpellTargetProfile.java
@@ -1,0 +1,17 @@
+package legend.game.combat.spells;
+
+public record SpellTargetProfile(TargetSide side, TargetScope scope, TargetLifeState lifeState) {
+  public SpellTargetProfile {
+    if(side == null) {
+      throw new IllegalArgumentException("Spell target side cannot be null");
+    }
+
+    if(scope == null) {
+      throw new IllegalArgumentException("Spell target scope cannot be null");
+    }
+
+    if(lifeState == null) {
+      throw new IllegalArgumentException("Spell target life state cannot be null");
+    }
+  }
+}

--- a/src/main/java/legend/game/combat/spells/SpellTargetProfile.java
+++ b/src/main/java/legend/game/combat/spells/SpellTargetProfile.java
@@ -1,5 +1,12 @@
 package legend.game.combat.spells;
 
+/**
+ * Immutable targeting rules for one {@link SpellEffectPlan}.
+ *
+ * @param side relationship to the caster that a target must have
+ * @param scope whether one or every eligible target is selected
+ * @param lifeState life state that a target must have
+ */
 public record SpellTargetProfile(TargetSide side, TargetScope scope, TargetLifeState lifeState) {
   public SpellTargetProfile {
     if(side == null) {

--- a/src/main/java/legend/game/combat/spells/StatModifierSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/StatModifierSpellEffect.java
@@ -1,5 +1,12 @@
 package legend.game.combat.spells;
 
+/**
+ * Replaces the selected target's active modifier for one battle stat.
+ *
+ * @param stat battle stat whose active modifier is replaced
+ * @param amount raw modifier amount consumed by the battle stat calculation
+ * @param turns number of turns assigned to the modifier
+ */
 public record StatModifierSpellEffect(SpellStat stat, int amount, int turns) implements SpellEffect {
   public StatModifierSpellEffect {
     if(stat == null) {

--- a/src/main/java/legend/game/combat/spells/StatModifierSpellEffect.java
+++ b/src/main/java/legend/game/combat/spells/StatModifierSpellEffect.java
@@ -1,0 +1,9 @@
+package legend.game.combat.spells;
+
+public record StatModifierSpellEffect(SpellStat stat, int amount, int turns) implements SpellEffect {
+  public StatModifierSpellEffect {
+    if(stat == null) {
+      throw new IllegalArgumentException("Spell modifier stat cannot be null");
+    }
+  }
+}

--- a/src/main/java/legend/game/combat/spells/TargetLifeState.java
+++ b/src/main/java/legend/game/combat/spells/TargetLifeState.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public enum TargetLifeState { LIVING, DEAD, ANY }

--- a/src/main/java/legend/game/combat/spells/TargetLifeState.java
+++ b/src/main/java/legend/game/combat/spells/TargetLifeState.java
@@ -1,2 +1,12 @@
 package legend.game.combat.spells;
-public enum TargetLifeState { LIVING, DEAD, ANY }
+/** Restricts a spell plan to targets with a matching life state. */
+public enum TargetLifeState {
+    /** Targets whose current HP is greater than zero. */
+    LIVING,
+
+    /** Targets whose current HP is zero. */
+    DEAD,
+
+    /** Targets regardless of current HP. */
+    ANY,
+}

--- a/src/main/java/legend/game/combat/spells/TargetScope.java
+++ b/src/main/java/legend/game/combat/spells/TargetScope.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public enum TargetScope { SINGLE, ALL }

--- a/src/main/java/legend/game/combat/spells/TargetScope.java
+++ b/src/main/java/legend/game/combat/spells/TargetScope.java
@@ -1,2 +1,9 @@
 package legend.game.combat.spells;
-public enum TargetScope { SINGLE, ALL }
+/** Defines how many eligible battle entities a spell plan targets. */
+public enum TargetScope {
+    /** One eligible target, preferring the entity selected by the player. */
+    SINGLE,
+
+    /** Every eligible target. */
+    ALL,
+}

--- a/src/main/java/legend/game/combat/spells/TargetSide.java
+++ b/src/main/java/legend/game/combat/spells/TargetSide.java
@@ -1,2 +1,15 @@
 package legend.game.combat.spells;
-public enum TargetSide { SELF, ALLIES, ENEMIES, ANY }
+/** Restricts targets by their relationship to the caster. */
+public enum TargetSide {
+    /** Only the caster. */
+    SELF,
+
+    /** Battle entities on the caster's side. */
+    ALLIES,
+
+    /** Battle entities on the opposing side. */
+    ENEMIES,
+
+    /** Battle entities on either side, including the caster. */
+    ANY,
+}

--- a/src/main/java/legend/game/combat/spells/TargetSide.java
+++ b/src/main/java/legend/game/combat/spells/TargetSide.java
@@ -1,0 +1,2 @@
+package legend.game.combat.spells;
+public enum TargetSide { SELF, ALLIES, ENEMIES, ANY }

--- a/src/main/java/legend/game/combat/ui/SpellListMenu.java
+++ b/src/main/java/legend/game/combat/ui/SpellListMenu.java
@@ -118,9 +118,9 @@ public class SpellListMenu extends ListMenu {
     if(this.menuState_00 != 0 && (this.flags_02 & 0x1) != 0) {
       //LAB_800f5f50
       if((this.flags_02 & 0x40) != 0) {
-      final SpellStats0c spell = this.spells.spells_01.get(this.listScroll_1e + this.listIndex_24);
-      final String baseDescription = I18n.translate(spell.getTranslationKey("description"));
-      final String description = EVENTS.postEvent(new ResolveSpellDescriptionEvent(this.spells.character_00, spell.getRegistryId(), spell, baseDescription)).description;
+        final SpellStats0c spell = this.spells.spells_01.get(this.listScroll_1e + this.listIndex_24);
+        final String baseDescription = I18n.translate(spell.getTranslationKey("description"));
+        final String description = EVENTS.postEvent(new ResolveSpellDescriptionEvent(this.spells.character_00, spell.getRegistryId(), spell, baseDescription)).description;
 
         //Selected item description
         if(this.description == null) {

--- a/src/main/java/legend/game/combat/ui/SpellListMenu.java
+++ b/src/main/java/legend/game/combat/ui/SpellListMenu.java
@@ -9,7 +9,7 @@ import legend.game.inventory.SpellStats0c;
 import legend.game.inventory.screens.FontOptions;
 import legend.game.inventory.screens.HorizontalAlign;
 import legend.game.inventory.screens.TextColour;
-import legend.game.modding.events.battle.SpellStatsEvent;
+import legend.game.modding.events.battle.ResolveSpellDescriptionEvent;
 import legend.game.scripting.RunningScript;
 import legend.game.ui.UiBox;
 import legend.lodmod.LodMod;
@@ -118,7 +118,9 @@ public class SpellListMenu extends ListMenu {
     if(this.menuState_00 != 0 && (this.flags_02 & 0x1) != 0) {
       //LAB_800f5f50
       if((this.flags_02 & 0x40) != 0) {
-        final SpellStats0c spell = EVENTS.postEvent(new SpellStatsEvent(this.spells.character_00, this.spells.spells_01.get(this.listScroll_1e + this.listIndex_24))).spell;
+      final SpellStats0c spell = this.spells.spells_01.get(this.listScroll_1e + this.listIndex_24);
+      final String baseDescription = I18n.translate(spell.getTranslationKey("description"));
+      final String description = EVENTS.postEvent(new ResolveSpellDescriptionEvent(this.spells.character_00, spell.getRegistryId(), spell, baseDescription)).description;
 
         //Selected item description
         if(this.description == null) {
@@ -129,7 +131,7 @@ public class SpellListMenu extends ListMenu {
 
         this.fontOptions.trim(0);
         this.fontOptions.horizontalAlign(HorizontalAlign.CENTRE);
-        renderText(I18n.translate(spell.getTranslationKey("description")), 160, 157, this.fontOptions);
+      renderText(description, 160, 157, this.fontOptions);
       }
     }
   }

--- a/src/main/java/legend/game/inventory/SpellStats0c.java
+++ b/src/main/java/legend/game/inventory/SpellStats0c.java
@@ -73,11 +73,26 @@ public abstract class SpellStats0c extends RegistryEntry implements ScriptReadab
     return -1;
   }
 
-  public List<SpellEffectPlan> getEffectPlans() {
-    return this.effectPlans;
-  }
+    /**
+     * Returns the immutable effect plans currently attached to this spell.
+     *
+     * @return immutable, non-empty effect-plan list
+     */
+    public List<SpellEffectPlan> getEffectPlans() {
+        return this.effectPlans;
+    }
 
-  public final void setEffectPlans(final List<SpellEffectPlan> effectPlans) {
+    /**
+     * Replaces all effect plans attached to this spell.
+     *
+     * <p>The list is defensively copied. Plans are evaluated in list order when the spell is cast,
+     * and only {@link legend.game.combat.spells.ExecutionMode#DECLARATIVE} plans are interpreted by
+     * the declarative runtime.</p>
+     *
+     * @param effectPlans non-null, non-empty plans with no null entries
+     * @throws IllegalArgumentException if the list is null, empty, or contains a null plan
+     */
+    public final void setEffectPlans(final List<SpellEffectPlan> effectPlans) {
     if(effectPlans == null || effectPlans.isEmpty()) {
       throw new IllegalArgumentException("Spell effect plans cannot be null or empty");
     }

--- a/src/main/java/legend/game/inventory/SpellStats0c.java
+++ b/src/main/java/legend/game/inventory/SpellStats0c.java
@@ -73,20 +73,8 @@ public abstract class SpellStats0c extends RegistryEntry implements ScriptReadab
     return -1;
   }
 
-  public SpellEffectPlan getEffectPlan() {
-    return this.effectPlans.get(0);
-  }
-
   public List<SpellEffectPlan> getEffectPlans() {
     return this.effectPlans;
-  }
-
-  public final void setEffectPlan(final SpellEffectPlan effectPlan) {
-    if(effectPlan == null) {
-      throw new IllegalArgumentException("Spell effect plan cannot be null");
-    }
-
-    this.setEffectPlans(List.of(effectPlan));
   }
 
   public final void setEffectPlans(final List<SpellEffectPlan> effectPlans) {

--- a/src/main/java/legend/game/inventory/SpellStats0c.java
+++ b/src/main/java/legend/game/inventory/SpellStats0c.java
@@ -3,12 +3,15 @@ package legend.game.inventory;
 import legend.game.characters.Element;
 import legend.game.combat.Battle;
 import legend.game.combat.effects.ScriptDeffEffect;
+import legend.game.combat.spells.SpellEffectPlan;
 import legend.game.combat.types.BattleObject;
 import legend.game.scripting.Param;
 import legend.game.scripting.ScriptReadable;
 import legend.game.scripting.ScriptState;
 import org.legendofdragoon.modloader.registries.RegistryDelegate;
 import org.legendofdragoon.modloader.registries.RegistryEntry;
+
+import java.util.List;
 
 public abstract class SpellStats0c extends RegistryEntry implements ScriptReadable {
   /**
@@ -46,6 +49,7 @@ public abstract class SpellStats0c extends RegistryEntry implements ScriptReadab
    */
   public final int buffType_0a;
   public final int _0b;
+  private List<SpellEffectPlan> effectPlans = List.of(SpellEffectPlan.legacy());
 
   public SpellStats0c(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b) {
     this.targetType_00 = targetType;
@@ -67,6 +71,36 @@ public abstract class SpellStats0c extends RegistryEntry implements ScriptReadab
   /** A battle stage ID if this spell changes the battle stage, or -1 if it doesn't */
   public int getBattleStage() {
     return -1;
+  }
+
+  public SpellEffectPlan getEffectPlan() {
+    return this.effectPlans.get(0);
+  }
+
+  public List<SpellEffectPlan> getEffectPlans() {
+    return this.effectPlans;
+  }
+
+  public final void setEffectPlan(final SpellEffectPlan effectPlan) {
+    if(effectPlan == null) {
+      throw new IllegalArgumentException("Spell effect plan cannot be null");
+    }
+
+    this.setEffectPlans(List.of(effectPlan));
+  }
+
+  public final void setEffectPlans(final List<SpellEffectPlan> effectPlans) {
+    if(effectPlans == null || effectPlans.isEmpty()) {
+      throw new IllegalArgumentException("Spell effect plans cannot be null or empty");
+    }
+
+    for(final SpellEffectPlan effectPlan : effectPlans) {
+      if(effectPlan == null) {
+        throw new IllegalArgumentException("Spell effect plan cannot be null");
+      }
+    }
+
+    this.effectPlans = List.copyOf(effectPlans);
   }
 
   @Override

--- a/src/main/java/legend/game/inventory/screens/StatusScreen.java
+++ b/src/main/java/legend/game/inventory/screens/StatusScreen.java
@@ -5,12 +5,14 @@ import legend.game.characters.CharacterData2c;
 import legend.game.i18n.I18n;
 import legend.game.inventory.SpellStats0c;
 import legend.game.inventory.screens.controls.CharacterCard;
+import legend.game.modding.events.battle.SpellStatsEvent;
 import legend.game.types.Renderable58;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
 import java.util.List;
 
 import static legend.core.GameEngine.CONFIG;
+import static legend.core.GameEngine.EVENTS;
 import static legend.core.GameEngine.REGISTRIES;
 import static legend.game.FullScreenEffects.startFadeEffect;
 import static legend.game.Menus.deallocateRenderables;
@@ -147,7 +149,9 @@ public class StatusScreen extends MenuScreen {
         if(i < unlockedSpells.size()) {
           this.renderNumber(198, 127 + (i - this.spellScrollIndex) * 14, i + 1, 2, 0, 0x7ca9);
           final RegistryId spellId = unlockedSpells.get(i);
-          final SpellStats0c spell = REGISTRIES.spells.getEntry(spellId).get();
+          final SpellStats0c baseSpell = REGISTRIES.spells.getEntry(spellId).get();
+          final SpellStatsEvent spellStatsEvent = EVENTS.postEvent(new SpellStatsEvent(character, baseSpell));
+          final SpellStats0c spell = spellStatsEvent.spell;
           renderText(I18n.translate(spell), 210, 125 + (i - this.spellScrollIndex) * 14, UI_TEXT);
           this.renderNumber(342, 128 + (i - this.spellScrollIndex) * 14, spell.mp_06, 3);
         }

--- a/src/main/java/legend/game/modding/events/battle/ResolveSpellDescriptionEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/ResolveSpellDescriptionEvent.java
@@ -5,16 +5,44 @@ import legend.game.inventory.SpellStats0c;
 import org.legendofdragoon.modloader.events.Event;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
+/**
+ * Fired when a player spell description is requested for display in battle.
+ *
+ * <p>This event may be fired repeatedly while the spell menu is displayed. Listeners may replace
+ * {@link #description} with the text the menu should display. The other fields provide read-only
+ * context for producing that text.</p>
+ */
 public class ResolveSpellDescriptionEvent extends Event {
-  public final CharacterData2c character;
-  public final RegistryId spellId;
-  public final SpellStats0c spell;
-  public final String baseDescription;
-  public String description;
+    /** The player character whose spell description is being requested. */
+    public final CharacterData2c character;
 
-  public ResolveSpellDescriptionEvent(final CharacterData2c character, final RegistryId spellId, final SpellStats0c spell, final String baseDescription) {
-    this.character = character;
-    this.spellId = spellId;
+    /** The registry ID of the spell being described. */
+    public final RegistryId spellId;
+
+    /** The effective spell stats associated with the displayed spell. */
+    public final SpellStats0c spell;
+
+    /** The translated description before any listener-provided replacement. */
+    public final String baseDescription;
+
+    /**
+     * The description returned to the menu after the event.
+     *
+     * <p>This initially contains {@link #baseDescription}. Listeners may assign a replacement.</p>
+     */
+    public String description;
+
+    /**
+     * Creates a spell-description request.
+     *
+     * @param character the player character whose spell description is being requested
+     * @param spellId the registry ID of the spell being described
+     * @param spell the effective spell stats associated with the displayed spell
+     * @param baseDescription the translated description used as the initial result
+     */
+    public ResolveSpellDescriptionEvent(final CharacterData2c character, final RegistryId spellId, final SpellStats0c spell, final String baseDescription) {
+        this.character = character;
+        this.spellId = spellId;
     this.spell = spell;
     this.baseDescription = baseDescription;
     this.description = baseDescription;

--- a/src/main/java/legend/game/modding/events/battle/ResolveSpellDescriptionEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/ResolveSpellDescriptionEvent.java
@@ -1,0 +1,22 @@
+package legend.game.modding.events.battle;
+
+import legend.game.characters.CharacterData2c;
+import legend.game.inventory.SpellStats0c;
+import org.legendofdragoon.modloader.events.Event;
+import org.legendofdragoon.modloader.registries.RegistryId;
+
+public class ResolveSpellDescriptionEvent extends Event {
+  public final CharacterData2c character;
+  public final RegistryId spellId;
+  public final SpellStats0c spell;
+  public final String baseDescription;
+  public String description;
+
+  public ResolveSpellDescriptionEvent(final CharacterData2c character, final RegistryId spellId, final SpellStats0c spell, final String baseDescription) {
+    this.character = character;
+    this.spellId = spellId;
+    this.spell = spell;
+    this.baseDescription = baseDescription;
+    this.description = baseDescription;
+  }
+}

--- a/src/main/java/legend/game/modding/events/battle/SpellStatsEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/SpellStatsEvent.java
@@ -3,13 +3,22 @@ package legend.game.modding.events.battle;
 import legend.game.characters.CharacterData2c;
 import legend.game.inventory.SpellStats0c;
 import org.legendofdragoon.modloader.events.Event;
+import org.legendofdragoon.modloader.registries.RegistryId;
 
 public class SpellStatsEvent extends Event {
   public final CharacterData2c character;
+  public final RegistryId spellId;
+  public final SpellStats0c baseSpell;
   public SpellStats0c spell;
 
   public SpellStatsEvent(final CharacterData2c character, final SpellStats0c spell) {
+    this(character, spell.getRegistryId(), spell);
+  }
+
+  public SpellStatsEvent(final CharacterData2c character, final RegistryId spellId, final SpellStats0c baseSpell) {
     this.character = character;
-    this.spell = spell;
+    this.spellId = spellId;
+    this.baseSpell = baseSpell;
+    this.spell = baseSpell;
   }
 }

--- a/src/main/java/legend/game/modding/events/battle/SpellStatsEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/SpellStatsEvent.java
@@ -5,19 +5,54 @@ import legend.game.inventory.SpellStats0c;
 import org.legendofdragoon.modloader.events.Event;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
+/**
+ * Fired when the effective stats for a player spell are requested.
+ *
+ * <p>This event may be fired during battle setup, when a spell becomes active, or when spell
+ * stats are displayed in a menu. It may therefore be fired more than once for the same character
+ * and spell.</p>
+ *
+ * <p>Listeners may replace {@link #spell} with the stats the requester should use. The other
+ * fields provide read-only context. Prefer assigning a replacement to {@code spell} instead of
+ * modifying {@link #baseSpell} so the registered base spell remains unchanged.</p>
+ */
 public class SpellStatsEvent extends Event {
-  public final CharacterData2c character;
-  public final RegistryId spellId;
-  public final SpellStats0c baseSpell;
-  public SpellStats0c spell;
+    /** The player character whose spell stats are being requested. */
+    public final CharacterData2c character;
 
-  public SpellStatsEvent(final CharacterData2c character, final SpellStats0c spell) {
-    this(character, spell.getRegistryId(), spell);
-  }
+    /** The registry ID of the requested spell. */
+    public final RegistryId spellId;
 
-  public SpellStatsEvent(final CharacterData2c character, final RegistryId spellId, final SpellStats0c baseSpell) {
-    this.character = character;
-    this.spellId = spellId;
+    /** The registered spell stats before any listener-provided replacement. */
+    public final SpellStats0c baseSpell;
+
+    /**
+     * The effective spell stats returned to the requester after the event.
+     *
+     * <p>This initially references {@link #baseSpell}. Listeners may assign a replacement.</p>
+     */
+    public SpellStats0c spell;
+
+    /**
+     * Creates a spell-stats request using the registered ID of {@code spell}.
+     *
+     * @param character the player character whose spell stats are being requested
+     * @param spell the registered spell stats used as both the base value and initial result
+     */
+    public SpellStatsEvent(final CharacterData2c character, final SpellStats0c spell) {
+        this(character, spell.getRegistryId(), spell);
+    }
+
+    /**
+     * Creates a spell-stats request for a specific spell ID and base value.
+     *
+     * @param character the player character whose spell stats are being requested
+     * @param spellId the registry ID of the requested spell
+     * @param baseSpell the registered spell stats used as the initial result
+     */
+    public SpellStatsEvent(final CharacterData2c character, final RegistryId spellId, final SpellStats0c baseSpell) {
+        this.character = character;
+        this.spellId = spellId;
     this.baseSpell = baseSpell;
     this.spell = baseSpell;
   }

--- a/src/main/java/legend/lodmod/LodSpellEffectPlans.java
+++ b/src/main/java/legend/lodmod/LodSpellEffectPlans.java
@@ -1,0 +1,46 @@
+package legend.lodmod;
+
+import legend.game.combat.spells.CleanseSpellEffect;
+import legend.game.combat.spells.DamageSpellEffect;
+import legend.game.combat.spells.ExecutionMode;
+import legend.game.combat.spells.HealHpSpellEffect;
+import legend.game.combat.spells.ReviveSpellEffect;
+import legend.game.combat.spells.SpellEffect;
+import legend.game.combat.spells.SpellEffectPlan;
+import legend.game.combat.spells.SpellStat;
+import legend.game.combat.spells.SpellTargetProfile;
+import legend.game.combat.spells.StatModifierSpellEffect;
+import legend.game.combat.spells.TargetLifeState;
+import legend.game.combat.spells.TargetScope;
+import legend.game.combat.spells.TargetSide;
+
+import java.util.List;
+
+final class LodSpellEffectPlans {
+  private LodSpellEffectPlans() { }
+
+  static SpellEffectPlan damage(final TargetScope scope, final int power) {
+    return enemies(scope, new DamageSpellEffect(power));
+  }
+
+  static SpellEffectPlan damageResistance() {
+    return allies(
+      TargetScope.ALL,
+      TargetLifeState.LIVING,
+      new StatModifierSpellEffect(SpellStat.DEFENCE, 50, 3),
+      new StatModifierSpellEffect(SpellStat.MAGIC_DEFENCE, 50, 3)
+    );
+  }
+
+  static SpellEffectPlan reviveAndRecover(final TargetScope scope, final int recovery) {
+    return allies(scope, TargetLifeState.ANY, new ReviveSpellEffect(50), new CleanseSpellEffect(0xff), new HealHpSpellEffect(recovery, true));
+  }
+
+  static SpellEffectPlan enemies(final TargetScope scope, final SpellEffect... effects) {
+    return new SpellEffectPlan(new SpellTargetProfile(TargetSide.ENEMIES, scope, TargetLifeState.LIVING), List.of(effects), ExecutionMode.LEGACY);
+  }
+
+  static SpellEffectPlan allies(final TargetScope scope, final TargetLifeState lifeState, final SpellEffect... effects) {
+    return new SpellEffectPlan(new SpellTargetProfile(TargetSide.ALLIES, scope, lifeState), List.of(effects), ExecutionMode.LEGACY);
+  }
+}

--- a/src/main/java/legend/lodmod/LodSpells.java
+++ b/src/main/java/legend/lodmod/LodSpells.java
@@ -1,11 +1,20 @@
 package legend.lodmod;
 
+import legend.game.combat.spells.ApplyStatusSpellEffect;
+import legend.game.combat.spells.CleanseSpellEffect;
+import legend.game.combat.spells.DamageSpellEffect;
+import legend.game.combat.spells.DrainHpSpellEffect;
+import legend.game.combat.spells.HealHpSpellEffect;
+import legend.game.combat.spells.TargetLifeState;
+import legend.game.combat.spells.TargetScope;
 import legend.game.inventory.SpellRegistryEvent;
 import legend.game.inventory.SpellStats0c;
 import legend.lodmod.spells.DragonSpell;
 import legend.lodmod.spells.RetailSpell;
 import org.legendofdragoon.modloader.registries.Registrar;
 import org.legendofdragoon.modloader.registries.RegistryDelegate;
+
+import java.util.List;
 
 import static legend.core.GameEngine.REGISTRIES;
 
@@ -14,41 +23,41 @@ public final class LodSpells {
 
   private static final Registrar<SpellStats0c, SpellRegistryEvent> REGISTRAR = new Registrar<>(REGISTRIES.spells, LodMod.MOD_ID);
 
-  public static final RegistryDelegate<RetailSpell> FLAMESHOT = REGISTRAR.register("flameshot", () -> new RetailSpell(0xc0, 0, 0, 0x20, 0, 100, 10, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 0));
-  public static final RegistryDelegate<RetailSpell> EXPLOSION = REGISTRAR.register("explosion", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 1));
-  public static final RegistryDelegate<RetailSpell> FINAL_BURST = REGISTRAR.register("final_burst", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 2));
-  public static final RegistryDelegate<RetailSpell> RED_EYED_DRAGON = REGISTRAR.register("red_eyed_dragon", () -> new DragonSpell(0xc8, 0, 0, 0x10, 0, 100, 80, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 3, 71));
-  public static final RegistryDelegate<RetailSpell> DIVINE_DG_CANNON = REGISTRAR.register("divine_dg_cannon", () -> new RetailSpell(0xc0, 0, 0, 0x2, 0, 100, 50, 0, LodMod.DIVINE_ELEMENT, 0, 0, 0, 4));
-  public static final RegistryDelegate<RetailSpell> WING_BLASTER = REGISTRAR.register("wing_blaster", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 5));
-  public static final RegistryDelegate<RetailSpell> GASPLESS = REGISTRAR.register("gaspless", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 6));
-  public static final RegistryDelegate<RetailSpell> BLOSSOM_STORM = REGISTRAR.register("blossom_storm", () -> new RetailSpell(0x88, 0x4, 0x10, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0xc0, 0, 7));
-  public static final RegistryDelegate<RetailSpell> JADE_DRAGON = REGISTRAR.register("jade_dragon", () -> new DragonSpell(0xc8, 0, 0, 0x10, 0, 100, 80, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 8, 72));
-  public static final RegistryDelegate<RetailSpell> DIVINE_DG_BALL = REGISTRAR.register("divine_dg_ball", () -> new RetailSpell(0xc8, 0, 0, 0x8, 0, 100, 50, 0, LodMod.DIVINE_ELEMENT, 0, 0, 0, 9));
-  public static final RegistryDelegate<RetailSpell> STAR_CHILDREN = REGISTRAR.register("star_children", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 10));
-  public static final RegistryDelegate<RetailSpell> MOON_LIGHT = REGISTRAR.register("moon_light", () -> new RetailSpell(0x80, 4, 0x2, 0, 100, 100, 10, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 11));
-  public static final RegistryDelegate<RetailSpell> GATES_OF_HEAVEN = REGISTRAR.register("gates_of_heaven", () -> new RetailSpell(0x88, 0x4, 0x2, 0, 50, 100, 30, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 12));
-  public static final RegistryDelegate<RetailSpell> WHITE_SILVER_DRAGON = REGISTRAR.register("white_silver_dragon", () -> new DragonSpell(0xc8, 0x2, 0, 0x10, 0, 100, 80, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 13, 75));
-  public static final RegistryDelegate<RetailSpell> ALBERT_WING_BLASTER = REGISTRAR.register("albert_wing_blaster", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 14));
-  public static final RegistryDelegate<RetailSpell> ASTRAL_DRAIN = REGISTRAR.register("astral_drain", () -> new RetailSpell(0xc0, 0x2, 0, 0x20, 0, 100, 10, 0, LodMod.DARK_ELEMENT, 0, 0, 0, 15));
-  public static final RegistryDelegate<RetailSpell> DEATH_DIMENSION = REGISTRAR.register("death_dimension", () -> new RetailSpell(0xc8, 0, 0x20, 0, 0, 100, 20, 100, LodMod.DARK_ELEMENT, 0x8, 0, 0, 16));
-  public static final RegistryDelegate<RetailSpell> ALBERT_GASPLESS = REGISTRAR.register("albert_gaspless", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 17));
-  public static final RegistryDelegate<RetailSpell> DEMONS_GATE = REGISTRAR.register("demons_gate", () -> new RetailSpell(0xc8, 0x80, 0, 0, 0, 100, 30, 100, LodMod.DARK_ELEMENT, 0, 0, 0, 18));
-  public static final RegistryDelegate<RetailSpell> DARK_DRAGON = REGISTRAR.register("dark_dragon", () -> new DragonSpell(0xc0, 0, 0, 0x8, 0, 100, 80, 0, LodMod.DARK_ELEMENT, 0, 0, 0, 19, 74));
-  public static final RegistryDelegate<RetailSpell> ATOMIC_MIND = REGISTRAR.register("atomic_mind", () -> new RetailSpell(0xc0, 0, 0, 0, 0, 100, 10, 0, LodMod.THUNDER_ELEMENT, 0, 0, 0, 20));
-  public static final RegistryDelegate<RetailSpell> THUNDER_KID = REGISTRAR.register("thunder_kid", () -> new RetailSpell(0xc0, 0, 0x20, 0x20, 0, 100, 20, 100, LodMod.THUNDER_ELEMENT, 0x10, 0, 0, 21));
-  public static final RegistryDelegate<RetailSpell> THUNDER_GOD = REGISTRAR.register("thunder_god", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.THUNDER_ELEMENT, 0, 0, 0, 22));
-  public static final RegistryDelegate<RetailSpell> VIOLET_DRAGON = REGISTRAR.register("violet_dragon", () -> new DragonSpell(0xc0, 0, 0, 0x8, 0, 100, 80, 0, LodMod.THUNDER_ELEMENT, 0, 0, 0, 23, 77));
-  public static final RegistryDelegate<RetailSpell> FREEZING_RING = REGISTRAR.register("freezing_ring", () -> new RetailSpell(0xc0, 0, 0, 0x20, 0, 100, 10, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 24));
-  public static final RegistryDelegate<RetailSpell> RAINBOW_BREATH = REGISTRAR.register("rainbow_breath", () -> new RetailSpell(0x88, 0x4, 0x2, 0, 50, 100, 20, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 25));
-  public static final RegistryDelegate<RetailSpell> ROSE_STORM = REGISTRAR.register("rose_storm", () -> new RetailSpell(0x88, 4, 0x10, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0xc0, 0, 26));
-  public static final RegistryDelegate<RetailSpell> DIAMOND_DUST = REGISTRAR.register("diamond_dust", () -> new RetailSpell(0xc8, 0, 0, 0x20, 0, 100, 30, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 27));
-  public static final RegistryDelegate<RetailSpell> BLUE_SEA_DRAGON = REGISTRAR.register("blue_sea_dragon", () -> new DragonSpell(0xc0, 0, 0, 0x8, 0, 100, 80, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 28, 73));
-  public static final RegistryDelegate<RetailSpell> GRAND_STREAM = REGISTRAR.register("grand_stream", () -> new RetailSpell(0xc8, 0, 0, 0x40, 0, 100, 20, 0, LodMod.EARTH_ELEMENT, 0, 0, 0, 29));
-  public static final RegistryDelegate<RetailSpell> METEOR_STRIKE = REGISTRAR.register("meteor_strike", () -> new RetailSpell(0xc8, 0, 0, 0x20, 0, 100, 30, 0, LodMod.EARTH_ELEMENT, 0, 0, 0, 30));
-  public static final RegistryDelegate<RetailSpell> GOLDEN_DRAGON = REGISTRAR.register("golden_dragon", () -> new DragonSpell(0xc8, 0, 0, 0x10, 0, 100, 80, 0, LodMod.EARTH_ELEMENT, 0, 0, 0, 31, 76));
-  public static final RegistryDelegate<RetailSpell> MIRANDA_STAR_CHILDREN = REGISTRAR.register("miranda_star_children", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 65));
-  public static final RegistryDelegate<RetailSpell> MIRANDA_MOON_LIGHT = REGISTRAR.register("miranda_moon_light", () -> new RetailSpell(0x80, 0x4, 0x2, 0, 100, 100, 10, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 66));
-  public static final RegistryDelegate<RetailSpell> MIRANDA_GATES_OF_HEAVEN = REGISTRAR.register("miranda_gates_of_heaven", () -> new RetailSpell(0x88, 0x4, 0x2, 0, 50, 100, 30, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 67));
+  public static final RegistryDelegate<RetailSpell> FLAMESHOT = REGISTRAR.register("flameshot", () -> new RetailSpell(0xc0, 0, 0, 0x20, 0, 100, 10, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 0, LodSpellEffectPlans.damage(TargetScope.SINGLE, 50)));
+  public static final RegistryDelegate<RetailSpell> EXPLOSION = REGISTRAR.register("explosion", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 1, LodSpellEffectPlans.damage(TargetScope.ALL, 25)));
+  public static final RegistryDelegate<RetailSpell> FINAL_BURST = REGISTRAR.register("final_burst", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 2, LodSpellEffectPlans.damage(TargetScope.SINGLE, 75)));
+  public static final RegistryDelegate<RetailSpell> RED_EYED_DRAGON = REGISTRAR.register("red_eyed_dragon", () -> new DragonSpell(0xc8, 0, 0, 0x10, 0, 100, 80, 0, LodMod.FIRE_ELEMENT, 0, 0, 0, 3, 71, LodSpellEffectPlans.damage(TargetScope.ALL, 75)));
+  public static final RegistryDelegate<RetailSpell> DIVINE_DG_CANNON = REGISTRAR.register("divine_dg_cannon", () -> new RetailSpell(0xc0, 0, 0, 0x2, 0, 100, 50, 0, LodMod.DIVINE_ELEMENT, 0, 0, 0, 4, LodSpellEffectPlans.damage(TargetScope.SINGLE, 150)));
+  public static final RegistryDelegate<RetailSpell> WING_BLASTER = REGISTRAR.register("wing_blaster", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 5, LodSpellEffectPlans.damage(TargetScope.ALL, 25)));
+  public static final RegistryDelegate<RetailSpell> GASPLESS = REGISTRAR.register("gaspless", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 6, LodSpellEffectPlans.damage(TargetScope.SINGLE, 75)));
+  public static final RegistryDelegate<RetailSpell> BLOSSOM_STORM = REGISTRAR.register("blossom_storm", () -> new RetailSpell(0x88, 0x4, 0x10, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0xc0, 0, 7, LodSpellEffectPlans.damageResistance()));
+  public static final RegistryDelegate<RetailSpell> JADE_DRAGON = REGISTRAR.register("jade_dragon", () -> new DragonSpell(0xc8, 0, 0, 0x10, 0, 100, 80, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 8, 72, LodSpellEffectPlans.damage(TargetScope.ALL, 75)));
+  public static final RegistryDelegate<RetailSpell> DIVINE_DG_BALL = REGISTRAR.register("divine_dg_ball", () -> new RetailSpell(0xc8, 0, 0, 0x8, 0, 100, 50, 0, LodMod.DIVINE_ELEMENT, 0, 0, 0, 9, LodSpellEffectPlans.damage(TargetScope.ALL, 100)));
+  public static final RegistryDelegate<RetailSpell> STAR_CHILDREN = REGISTRAR.register("star_children", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 10, LodSpellEffectPlans.damage(TargetScope.ALL, 25)));
+  public static final RegistryDelegate<RetailSpell> MOON_LIGHT = REGISTRAR.register("moon_light", () -> new RetailSpell(0x80, 4, 0x2, 0, 100, 100, 10, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 11, LodSpellEffectPlans.reviveAndRecover(TargetScope.SINGLE, 100)));
+  public static final RegistryDelegate<RetailSpell> GATES_OF_HEAVEN = REGISTRAR.register("gates_of_heaven", () -> new RetailSpell(0x88, 0x4, 0x2, 0, 50, 100, 30, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 12, LodSpellEffectPlans.reviveAndRecover(TargetScope.ALL, 50)));
+  public static final RegistryDelegate<RetailSpell> WHITE_SILVER_DRAGON = REGISTRAR.register("white_silver_dragon", () -> new DragonSpell(0xc8, 0x2, 0, 0x10, 0, 100, 80, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 13, 75, List.of(LodSpellEffectPlans.enemies(TargetScope.ALL, new DamageSpellEffect(75)), LodSpellEffectPlans.allies(TargetScope.ALL, TargetLifeState.LIVING, new HealHpSpellEffect(100, true)))));
+  public static final RegistryDelegate<RetailSpell> ALBERT_WING_BLASTER = REGISTRAR.register("albert_wing_blaster", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 14, LodSpellEffectPlans.damage(TargetScope.ALL, 25)));
+  public static final RegistryDelegate<RetailSpell> ASTRAL_DRAIN = REGISTRAR.register("astral_drain", () -> new RetailSpell(0xc0, 0x2, 0, 0x20, 0, 100, 10, 0, LodMod.DARK_ELEMENT, 0, 0, 0, 15, LodSpellEffectPlans.enemies(TargetScope.SINGLE, new DamageSpellEffect(50), new DrainHpSpellEffect(100))));
+  public static final RegistryDelegate<RetailSpell> DEATH_DIMENSION = REGISTRAR.register("death_dimension", () -> new RetailSpell(0xc8, 0, 0x20, 0, 0, 100, 20, 100, LodMod.DARK_ELEMENT, 0x8, 0, 0, 16, LodSpellEffectPlans.enemies(TargetScope.ALL, new DamageSpellEffect(25), new ApplyStatusSpellEffect(0x8, 100))));
+  public static final RegistryDelegate<RetailSpell> ALBERT_GASPLESS = REGISTRAR.register("albert_gaspless", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.WIND_ELEMENT, 0, 0, 0, 17, LodSpellEffectPlans.damage(TargetScope.SINGLE, 75)));
+  public static final RegistryDelegate<RetailSpell> DEMONS_GATE = REGISTRAR.register("demons_gate", () -> new RetailSpell(0xc8, 0x80, 0, 0, 0, 100, 30, 100, LodMod.DARK_ELEMENT, 0, 0, 0, 18, LodSpellEffectPlans.enemies(TargetScope.ALL)));
+  public static final RegistryDelegate<RetailSpell> DARK_DRAGON = REGISTRAR.register("dark_dragon", () -> new DragonSpell(0xc0, 0, 0, 0x8, 0, 100, 80, 0, LodMod.DARK_ELEMENT, 0, 0, 0, 19, 74, LodSpellEffectPlans.damage(TargetScope.ALL, 100)));
+  public static final RegistryDelegate<RetailSpell> ATOMIC_MIND = REGISTRAR.register("atomic_mind", () -> new RetailSpell(0xc0, 0, 0, 0, 0, 100, 10, 0, LodMod.THUNDER_ELEMENT, 0, 0, 0, 20, LodSpellEffectPlans.damage(TargetScope.ALL, 25)));
+  public static final RegistryDelegate<RetailSpell> THUNDER_KID = REGISTRAR.register("thunder_kid", () -> new RetailSpell(0xc0, 0, 0x20, 0x20, 0, 100, 20, 100, LodMod.THUNDER_ELEMENT, 0x10, 0, 0, 21, LodSpellEffectPlans.enemies(TargetScope.SINGLE, new DamageSpellEffect(50), new ApplyStatusSpellEffect(0x10, 100))));
+  public static final RegistryDelegate<RetailSpell> THUNDER_GOD = REGISTRAR.register("thunder_god", () -> new RetailSpell(0xc0, 0, 0, 0x10, 0, 100, 30, 0, LodMod.THUNDER_ELEMENT, 0, 0, 0, 22, LodSpellEffectPlans.damage(TargetScope.SINGLE, 75)));
+  public static final RegistryDelegate<RetailSpell> VIOLET_DRAGON = REGISTRAR.register("violet_dragon", () -> new DragonSpell(0xc0, 0, 0, 0x8, 0, 100, 80, 0, LodMod.THUNDER_ELEMENT, 0, 0, 0, 23, 77, LodSpellEffectPlans.damage(TargetScope.ALL, 100)));
+  public static final RegistryDelegate<RetailSpell> FREEZING_RING = REGISTRAR.register("freezing_ring", () -> new RetailSpell(0xc0, 0, 0, 0x20, 0, 100, 10, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 24, LodSpellEffectPlans.damage(TargetScope.SINGLE, 50)));
+  public static final RegistryDelegate<RetailSpell> RAINBOW_BREATH = REGISTRAR.register("rainbow_breath", () -> new RetailSpell(0x88, 0x4, 0x2, 0, 50, 100, 20, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 25, LodSpellEffectPlans.allies(TargetScope.ALL, TargetLifeState.LIVING, new CleanseSpellEffect(0xff), new HealHpSpellEffect(50, true))));
+  public static final RegistryDelegate<RetailSpell> ROSE_STORM = REGISTRAR.register("rose_storm", () -> new RetailSpell(0x88, 4, 0x10, 0, 0, 100, 20, 0, LodMod.WIND_ELEMENT, 0, 0xc0, 0, 26, LodSpellEffectPlans.damageResistance()));
+  public static final RegistryDelegate<RetailSpell> DIAMOND_DUST = REGISTRAR.register("diamond_dust", () -> new RetailSpell(0xc8, 0, 0, 0x20, 0, 100, 30, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 27, LodSpellEffectPlans.damage(TargetScope.ALL, 50)));
+  public static final RegistryDelegate<RetailSpell> BLUE_SEA_DRAGON = REGISTRAR.register("blue_sea_dragon", () -> new DragonSpell(0xc0, 0, 0, 0x8, 0, 100, 80, 0, LodMod.WATER_ELEMENT, 0, 0, 0, 28, 73, LodSpellEffectPlans.damage(TargetScope.ALL, 100)));
+  public static final RegistryDelegate<RetailSpell> GRAND_STREAM = REGISTRAR.register("grand_stream", () -> new RetailSpell(0xc8, 0, 0, 0x40, 0, 100, 20, 0, LodMod.EARTH_ELEMENT, 0, 0, 0, 29, LodSpellEffectPlans.damage(TargetScope.ALL, 38)));
+  public static final RegistryDelegate<RetailSpell> METEOR_STRIKE = REGISTRAR.register("meteor_strike", () -> new RetailSpell(0xc8, 0, 0, 0x20, 0, 100, 30, 0, LodMod.EARTH_ELEMENT, 0, 0, 0, 30, LodSpellEffectPlans.damage(TargetScope.ALL, 50)));
+  public static final RegistryDelegate<RetailSpell> GOLDEN_DRAGON = REGISTRAR.register("golden_dragon", () -> new DragonSpell(0xc8, 0, 0, 0x10, 0, 100, 80, 0, LodMod.EARTH_ELEMENT, 0, 0, 0, 31, 76, LodSpellEffectPlans.damage(TargetScope.ALL, 75)));
+  public static final RegistryDelegate<RetailSpell> MIRANDA_STAR_CHILDREN = REGISTRAR.register("miranda_star_children", () -> new RetailSpell(0xc8, 0, 0, 0, 0, 100, 20, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 65, LodSpellEffectPlans.damage(TargetScope.ALL, 25)));
+  public static final RegistryDelegate<RetailSpell> MIRANDA_MOON_LIGHT = REGISTRAR.register("miranda_moon_light", () -> new RetailSpell(0x80, 0x4, 0x2, 0, 100, 100, 10, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 66, LodSpellEffectPlans.reviveAndRecover(TargetScope.SINGLE, 100)));
+  public static final RegistryDelegate<RetailSpell> MIRANDA_GATES_OF_HEAVEN = REGISTRAR.register("miranda_gates_of_heaven", () -> new RetailSpell(0x88, 0x4, 0x2, 0, 50, 100, 30, 0, LodMod.LIGHT_ELEMENT, 0, 0, 0, 67, LodSpellEffectPlans.reviveAndRecover(TargetScope.ALL, 50)));
 
   public static final RegistryDelegate<RetailSpell> SPELL32 = REGISTRAR.register("spell32", () -> new RetailSpell(0x40, 0, 0, 0x80, 0, 100, 0, 0, LodMod.NO_ELEMENT, 0, 0, 0, 32));
   public static final RegistryDelegate<RetailSpell> SPELL33 = REGISTRAR.register("spell33", () -> new RetailSpell(0x40, 0, 0, 0, 0, 100, 0, 0, LodMod.NO_ELEMENT, 0, 0, 0, 33));

--- a/src/main/java/legend/lodmod/spells/DragonSpell.java
+++ b/src/main/java/legend/lodmod/spells/DragonSpell.java
@@ -14,11 +14,49 @@ public class DragonSpell extends RetailSpell {
     this.battleStage = battleStage;
   }
 
-  public DragonSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final int battleStage, final SpellEffectPlan effectPlan) {
+    /**
+     * Creates a dragon spell with one effect plan.
+     *
+     * @param targetType retail target flags stored in {@link #targetType_00}
+     * @param flags retail spell flags stored in {@link #flags_01}
+     * @param specialEffect retail special-effect value stored in {@link #specialEffect_02}
+     * @param damage retail damage multiplier stored in {@link #damageMultiplier_03}
+     * @param multi retail multi-purpose value stored in {@link #multi_04}
+     * @param accuracy spell accuracy stored in {@link #accuracy_05}
+     * @param mp MP cost stored in {@link #mp_06}
+     * @param statusChance retail status chance stored in {@link #statusChance_07}
+     * @param element spell element
+     * @param statusType retail status mask stored in {@link #statusType_09}
+     * @param buffType retail buff mask stored in {@link #buffType_0a}
+     * @param _0b retail spell metadata stored in {@link #_0b}
+     * @param index Dragoon spell effect index used to load the spell's visual effect
+     * @param battleStage battle-stage override returned while the spell is active
+     * @param effectPlan effect plan attached to the spell
+     */
+    public DragonSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final int battleStage, final SpellEffectPlan effectPlan) {
     this(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index, battleStage, List.of(effectPlan));
   }
 
-  public DragonSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final int battleStage, final List<SpellEffectPlan> effectPlans) {
+    /**
+     * Creates a dragon spell with one or more effect plans.
+     *
+     * @param targetType retail target flags stored in {@link #targetType_00}
+     * @param flags retail spell flags stored in {@link #flags_01}
+     * @param specialEffect retail special-effect value stored in {@link #specialEffect_02}
+     * @param damage retail damage multiplier stored in {@link #damageMultiplier_03}
+     * @param multi retail multi-purpose value stored in {@link #multi_04}
+     * @param accuracy spell accuracy stored in {@link #accuracy_05}
+     * @param mp MP cost stored in {@link #mp_06}
+     * @param statusChance retail status chance stored in {@link #statusChance_07}
+     * @param element spell element
+     * @param statusType retail status mask stored in {@link #statusType_09}
+     * @param buffType retail buff mask stored in {@link #buffType_0a}
+     * @param _0b retail spell metadata stored in {@link #_0b}
+     * @param index Dragoon spell effect index used to load the spell's visual effect
+     * @param battleStage battle-stage override returned while the spell is active
+     * @param effectPlans non-null, non-empty effect plans defensively copied onto the spell
+     */
+    public DragonSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final int battleStage, final List<SpellEffectPlan> effectPlans) {
     super(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index, effectPlans);
     this.battleStage = battleStage;
   }

--- a/src/main/java/legend/lodmod/spells/DragonSpell.java
+++ b/src/main/java/legend/lodmod/spells/DragonSpell.java
@@ -1,13 +1,25 @@
 package legend.lodmod.spells;
 
 import legend.game.characters.Element;
+import legend.game.combat.spells.SpellEffectPlan;
 import org.legendofdragoon.modloader.registries.RegistryDelegate;
+
+import java.util.List;
 
 public class DragonSpell extends RetailSpell {
   private final int battleStage;
 
   public DragonSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final int battleStage) {
     super(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index);
+    this.battleStage = battleStage;
+  }
+
+  public DragonSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final int battleStage, final SpellEffectPlan effectPlan) {
+    this(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index, battleStage, List.of(effectPlan));
+  }
+
+  public DragonSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final int battleStage, final List<SpellEffectPlan> effectPlans) {
+    super(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index, effectPlans);
     this.battleStage = battleStage;
   }
 

--- a/src/main/java/legend/lodmod/spells/RetailSpell.java
+++ b/src/main/java/legend/lodmod/spells/RetailSpell.java
@@ -32,11 +32,47 @@ public class RetailSpell extends SpellStats0c {
     this.index = index;
   }
 
-  public RetailSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final SpellEffectPlan effectPlan) {
+    /**
+     * Creates a retail spell with one effect plan.
+     *
+     * @param targetType retail target flags stored in {@link #targetType_00}
+     * @param flags retail spell flags stored in {@link #flags_01}
+     * @param specialEffect retail special-effect value stored in {@link #specialEffect_02}
+     * @param damage retail damage multiplier stored in {@link #damageMultiplier_03}
+     * @param multi retail multi-purpose value stored in {@link #multi_04}
+     * @param accuracy spell accuracy stored in {@link #accuracy_05}
+     * @param mp MP cost stored in {@link #mp_06}
+     * @param statusChance retail status chance stored in {@link #statusChance_07}
+     * @param element spell element
+     * @param statusType retail status mask stored in {@link #statusType_09}
+     * @param buffType retail buff mask stored in {@link #buffType_0a}
+     * @param _0b retail spell metadata stored in {@link #_0b}
+     * @param index Dragoon spell effect index used to load the spell's visual effect
+     * @param effectPlan effect plan attached to the spell
+     */
+    public RetailSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final SpellEffectPlan effectPlan) {
     this(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index, List.of(effectPlan));
   }
 
-  public RetailSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final List<SpellEffectPlan> effectPlans) {
+    /**
+     * Creates a retail spell with one or more effect plans.
+     *
+     * @param targetType retail target flags stored in {@link #targetType_00}
+     * @param flags retail spell flags stored in {@link #flags_01}
+     * @param specialEffect retail special-effect value stored in {@link #specialEffect_02}
+     * @param damage retail damage multiplier stored in {@link #damageMultiplier_03}
+     * @param multi retail multi-purpose value stored in {@link #multi_04}
+     * @param accuracy spell accuracy stored in {@link #accuracy_05}
+     * @param mp MP cost stored in {@link #mp_06}
+     * @param statusChance retail status chance stored in {@link #statusChance_07}
+     * @param element spell element
+     * @param statusType retail status mask stored in {@link #statusType_09}
+     * @param buffType retail buff mask stored in {@link #buffType_0a}
+     * @param _0b retail spell metadata stored in {@link #_0b}
+     * @param index Dragoon spell effect index used to load the spell's visual effect
+     * @param effectPlans non-null, non-empty effect plans defensively copied onto the spell
+     */
+    public RetailSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final List<SpellEffectPlan> effectPlans) {
     this(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index);
     this.setEffectPlans(effectPlans);
   }

--- a/src/main/java/legend/lodmod/spells/RetailSpell.java
+++ b/src/main/java/legend/lodmod/spells/RetailSpell.java
@@ -3,6 +3,7 @@ package legend.lodmod.spells;
 import legend.game.characters.Element;
 import legend.game.combat.Battle;
 import legend.game.combat.effects.ScriptDeffEffect;
+import legend.game.combat.spells.SpellEffectPlan;
 import legend.game.combat.types.BattleObject;
 import legend.game.inventory.SpellStats0c;
 import legend.game.scripting.ScriptState;
@@ -12,6 +13,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.legendofdragoon.modloader.registries.RegistryDelegate;
+
+import java.util.List;
 
 import static legend.game.DrgnFiles.loadDrgnDir;
 import static legend.game.combat.Battle.deffManager_800c693c;
@@ -27,6 +30,15 @@ public class RetailSpell extends SpellStats0c {
   public RetailSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index) {
     super(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b);
     this.index = index;
+  }
+
+  public RetailSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final SpellEffectPlan effectPlan) {
+    this(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index, List.of(effectPlan));
+  }
+
+  public RetailSpell(final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final RegistryDelegate<Element> element, final int statusType, final int buffType, final int _0b, final int index, final List<SpellEffectPlan> effectPlans) {
+    this(targetType, flags, specialEffect, damage, multi, accuracy, mp, statusChance, element, statusType, buffType, _0b, index);
+    this.setEffectPlans(effectPlans);
   }
 
   @Override


### PR DESCRIPTION
## Main Goal
- Provide basic capabilities to modders to modify d spells
- Legacy d spell handling (see: scripts) remains primary supported pathway

## The Changes
#### SpellStatsEvent - Commit 1

- Make Spells Great Again by fleshing out `SpellStatsEvent` 
- Flesh out consistent resolution for combat, menus, MP costs, targeting, and other stuff
- Spell description event since if modders touch spells...they likely will want to customize what is shown in the spell desc

#### Spell Effects Java-land Implementation - Commit 2

- Down with scripts, with a java spell effect pipeline/executor
- Keep legacy behavior by default; `DECLARATIVE` replaces only legacy outcome calculations; scripts and animations continue
- Implement vanilla behavior plus new composable effects such as MP/SP restoration, drains, and regeneration but elsewise limited to a vanilla set of effects. Other more crazy effects could be added or hooks added but thats out of scope

#### Spell Effect Templates - Commit 3

- Give vanilla effect packages using registered `LodSpells` identities
- Give declarative randomization a known stock behavior package for each supported Dragoon spell
- Keep templates as replaceable internal SC definitions, modding API surface unaffected by any internal changes to these which is nice
- "Effect"
  - 'status' effects like fear, poison...etc
  - 'conditions' effects like revive, heal, cleanse across various target scopes

#### Multi-Effect Single Casts - Commit 5
- Do one spell cast but be able to have multiple Spell Effects occur from it, aka one animation plays but 5 different spell effects get played out

#### tldr
- Spicey break SC before 3.0 release dare ya

## Not in Scope
- Cross-character spell animations/deffs or anything crazy like that
- A system to add custom 'effects'
  - SC provides standard 'effects' and a standard 'effect pipeline'
  - Anyone wanting to extend this is likely implementing their own Battle.java (haha) or SpellEffectExecutor.java
  - Out of scope for this PR, but adding it would not break any of the modding APIs exposed in this PR
  - Exercise left for the reader
- DECLARATIVE or Java land stuff should be primary, while LEGACY / spellstats should be a secondary translation layer for scripts until DECLARATIVE has a native or adapter to scripts (if scripts and spells are to still be supported)
  - Atm, this implementation is the reverse. SpellStats / LEGACY is still the primary driver while java land spell effects are secondary and activated only via mods (for now)
  - Can see this overlap in Table A.1


## QA

#### Stock SC, no mods, PR
- https://streamable.com/kkg01h

#### Edit d-levels for mass dspell unlock post battle | Irongoon mod using and abusing the new SC d spell capabilities 
- https://streamable.com/yvcp0n

#### Fresh battle with rando'd spell desc and effects | Irongoon mod using and abusing the new SC d spell capabilities
- https://streamable.com/s9oy45

#### Crazy Rando Settings on Dspells | Irongoon mod using and abusing the new SC d spell capabilities
- https://streamable.com/5nnj6j

## Example Usage

```java
public final class MyCustomSpell extends SpellStats0c {
  private static final List<SpellEffectPlan> EFFECT_PLANS = List.of(
    new SpellEffectPlan(
      new SpellTargetProfile(TargetSide.ENEMIES, TargetScope.SINGLE, TargetLifeState.LIVING),
      List.of(
        new DamageSpellEffect(75),
        new DrainHpSpellEffect(50),
        new ApplyStatusSpellEffect(0x10, 50)
      ),
      ExecutionMode.DECLARATIVE
    )
  );

  public MyCustomSpell(final RegistryDelegate<Element> element) {
    super(0xc0, 0, 0, 0, 0, 100, 20, 50, element, 0x10, 0, 0);
    this.setEffectPlans(EFFECT_PLANS);
  }

  @Override
  public void loadDeff(
    final Battle battle,
    final ScriptState<? extends BattleObject> parent,
    final ScriptDeffEffect effect,
    final int flags,
    final int bentIndex,
    final int deffParam,
    final int entrypoint
  ) {
    // ...
  }
}
```

```java
private static final Registrar<SpellStats0c, SpellRegistryEvent> SPELL_REGISTRAR =
  new Registrar<>(REGISTRIES.spells, MOD_ID);

public static final RegistryDelegate<MyCustomSpell> MY_CUSTOM_SPELL =
  SPELL_REGISTRAR.register(
    "my_custom_spell",
    () -> new MyCustomSpell(LodMod.FIRE_ELEMENT)
  );

@EventListener
public static void registerSpells(final SpellRegistryEvent event) {
  SPELL_REGISTRAR.registryEvent(event);
}
```

#### Table A.1 - SpellStats vs Spell Effects overlap
Note that there is overlap, java land supports all outcomes where script land has some effects only as a side effect in the script itself (wsd dspell)

| `SpellStats0c` input | Current declarative relationship | Overlap |
| --- | --- | --- |
| `targetType` | `SpellTargetProfile.side()` and `scope()` replace outcome targeting. Legacy metadata still drives menu targeting and contains script-routing bits. `lifeState()` has no direct legacy equivalent | Partial |
| `flags` | Percentage-based effects use explicit effect properties. Drain and other outcomes use named effect types. Unknown or script-coupled flag behavior remains legacy-only | Partial/script-coupled |
| `specialEffect` | Named effects such as revive, cleanse, and status application replace understood outcomes, but there is no direct field mapping | Partial/script-coupled |
| `damageMultiplier` | `DamageSpellEffect.power()` supplies declarative damage potency and replaces the legacy multiplier calculation | Partial |
| `multi` | Declarative effects carry their own damage, healing, restoration, drain, or regeneration potency | Partial |
| `accuracy` | No effect-plan equivalent. The legacy field remains spell-level metadata used by the retail hit check before declarative execution | Spell-level |
| `mp` | No effect-plan equivalent. It remains the spell-level MP cost used by menus, affordability checks, and deduction | Spell-level |
| `statusChance` | `ApplyStatusSpellEffect.chance()` | Direct semantic replacement |
| `element` | No effect-plan equivalent. It remains spell-level metadata used by declarative damage, resistance, immunity, Dragoon Space, and HUD handling | Spell-level |
| `statusType` | `ApplyStatusSpellEffect.statusMask()` | Direct semantic replacement |
| `buffType` | `StatModifierSpellEffect` replaces the legacy mask with an explicit stat, amount, and duration | Direct semantic replacement |
| `_0b` | None | Unknown legacy field |