### PR TITLE
Remember Campaign Settings

### DIFF
--- a/src/main/java/legend/core/GameEngine.java
+++ b/src/main/java/legend/core/GameEngine.java
@@ -339,6 +339,7 @@ public final class GameEngine {
 
     // Load default bindings for input actions
     InputBindings.initBindings();
+    InputBindings.loadBindings(CONFIG);
 
     loadLang();
 

--- a/src/main/java/legend/core/platform/input/InputBindings.java
+++ b/src/main/java/legend/core/platform/input/InputBindings.java
@@ -33,7 +33,7 @@ public final class InputBindings {
 
   public static void loadBindings(final ConfigCollection config) {
     final Map<RegistryDelegate<InputAction>, List<InputActivation>> savedBindings = config.getConfig(CoreMod.CONTROLLER_KEYBINDS_CONFIG.get());
-    savedBindings.forEach(InputBindings::overwriteBindings);
+    savedBindings.forEach((action, activations) -> overwriteBindings(REGISTRIES.inputActions.getEntry(action.getId()), activations));
   }
 
   public static void saveBindings(final ConfigCollection config) {

--- a/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
+++ b/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
@@ -4,6 +4,7 @@ import legend.core.GameEngine;
 import legend.core.lang.I18nText;
 import legend.core.lang.RawText;
 import legend.core.platform.input.InputAction;
+import legend.core.platform.input.InputBindings;
 import legend.game.SItem;
 import legend.game.Scus94491BpeSegment_800b;
 import legend.game.i18n.I18n;
@@ -14,8 +15,10 @@ import legend.game.inventory.screens.controls.Dropdown;
 import legend.game.inventory.screens.controls.Label;
 import legend.game.inventory.screens.controls.Textbox;
 import legend.game.modding.coremod.CoreMod;
+import legend.game.modding.events.config.NewCampaignConfigEvent;
 import legend.game.modding.events.gamestate.NewGameEvent;
 import legend.game.saves.Campaign;
+import legend.game.saves.CampaignConfigDefaultsStorage;
 import legend.game.saves.ConfigStorage;
 import legend.game.saves.ConfigStorageLocation;
 import legend.game.saves.SaveFailedException;
@@ -63,6 +66,15 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     loadingNewGameState_800bdc34 = false;
 
     CONFIG.clearConfig(ConfigStorageLocation.CAMPAIGN);
+    final boolean rememberDefaults = CONFIG.getConfig(CoreMod.REMEMBER_CAMPAIGN_SETTINGS_CONFIG.get());
+
+    if(rememberDefaults) {
+      CampaignConfigDefaultsStorage.load(CONFIG);
+    }
+
+    EVENTS.postEvent(new NewCampaignConfigEvent(CONFIG, rememberDefaults));
+    InputBindings.initBindings();
+    InputBindings.loadBindings(CONFIG);
     this.enabledMods.addAll(MODS.getAllModIds());
 
     deallocateRenderables(0xff);

--- a/src/main/java/legend/game/modding/coremod/CoreMod.java
+++ b/src/main/java/legend/game/modding/coremod/CoreMod.java
@@ -69,9 +69,11 @@ import legend.game.modding.coremod.config.UnlockPartyConfig;
 import legend.game.modding.coremod.shops.EquipmentShopExtension;
 import legend.game.modding.coremod.shops.GoodShopExtension;
 import legend.game.modding.coremod.shops.ItemShopExtension;
+import legend.game.modding.events.config.CampaignConfigUpdatedEvent;
 import legend.game.modding.events.gamestate.GameLoadedEvent;
 import legend.game.modding.events.input.RegisterDefaultInputBindingsEvent;
 import legend.game.saves.BoolConfigEntry;
+import legend.game.saves.CampaignConfigDefaultsStorage;
 import legend.game.saves.CampaignNameConfigEntry;
 import legend.game.saves.ConfigCategory;
 import legend.game.saves.ConfigEntry;
@@ -129,6 +131,7 @@ public class CoreMod {
   public static final RegistryDelegate<MusicEffectsOverTimeGranularityConfigEntry> MUSIC_EFFECTS_OVER_TIME_GRANULARITY_CONFIG = CONFIG_REGISTRAR.register("music_effects_over_time_granularity", MusicEffectsOverTimeGranularityConfigEntry::new);
   public static final RegistryDelegate<CreateCrashSaveConfigEntry> CREATE_CRASH_SAVE_CONFIG = CONFIG_REGISTRAR.register("create_crash_save", CreateCrashSaveConfigEntry::new);
   public static final RegistryDelegate<ShowAdvancedOptionsConfigEntry> SHOW_ADVANCED_OPTIONS_CONFIG = CONFIG_REGISTRAR.register("show_advanced_options", ShowAdvancedOptionsConfigEntry::new);
+  public static final RegistryDelegate<BoolConfigEntry> REMEMBER_CAMPAIGN_SETTINGS_CONFIG = CONFIG_REGISTRAR.register("remember_campaign_settings", () -> new BoolConfigEntry(true, ConfigStorageLocation.GLOBAL, ConfigCategory.OTHER));
 
   public static final RegistryDelegate<LanguageConfigEntry> LANGUAGE_CONFIG = CONFIG_REGISTRAR.register("language", LanguageConfigEntry::new);
 
@@ -358,6 +361,15 @@ public class CoreMod {
     event.addExtension(new ItemShopExtension(), 1000);
     event.addExtension(new EquipmentShopExtension(), 1000);
     event.addExtension(new GoodShopExtension(), 1000);
+  }
+
+  @EventListener
+  public static void saveCampaignConfigDefaults(final CampaignConfigUpdatedEvent event) {
+    if(event.configCollection != GameEngine.CONFIG) return;
+    if(!GameEngine.CONFIG.getConfig(REMEMBER_CAMPAIGN_SETTINGS_CONFIG.get())) return;
+    if(!CampaignConfigDefaultsStorage.manages(event.config)) return;
+
+    CampaignConfigDefaultsStorage.save(event.configCollection);
   }
 
   @EventListener

--- a/src/main/java/legend/game/modding/events/config/CampaignConfigUpdatedEvent.java
+++ b/src/main/java/legend/game/modding/events/config/CampaignConfigUpdatedEvent.java
@@ -1,0 +1,14 @@
+package legend.game.modding.events.config;
+
+import legend.game.saves.ConfigCollection;
+import legend.game.saves.ConfigEntry;
+
+public class CampaignConfigUpdatedEvent extends ConfigEvent {
+  public final ConfigCollection configCollection;
+  public final ConfigEntry<?> config;
+
+  public CampaignConfigUpdatedEvent(final ConfigCollection configCollection, final ConfigEntry<?> config) {
+    this.configCollection = configCollection;
+    this.config = config;
+  }
+}

--- a/src/main/java/legend/game/modding/events/config/NewCampaignConfigEvent.java
+++ b/src/main/java/legend/game/modding/events/config/NewCampaignConfigEvent.java
@@ -1,0 +1,13 @@
+package legend.game.modding.events.config;
+
+import legend.game.saves.ConfigCollection;
+
+public class NewCampaignConfigEvent extends ConfigEvent {
+  public final ConfigCollection configCollection;
+  public final boolean rememberDefaults;
+
+  public NewCampaignConfigEvent(final ConfigCollection configCollection, final boolean rememberDefaults) {
+    this.configCollection = configCollection;
+    this.rememberDefaults = rememberDefaults;
+  }
+}

--- a/src/main/java/legend/game/saves/CampaignConfigDefaultsStorage.java
+++ b/src/main/java/legend/game/saves/CampaignConfigDefaultsStorage.java
@@ -1,0 +1,69 @@
+package legend.game.saves;
+
+import legend.core.memory.types.IntRef;
+import legend.game.unpacker.ExpandableFileData;
+import legend.game.unpacker.FileData;
+import org.legendofdragoon.modloader.registries.RegistryId;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Set;
+
+public final class CampaignConfigDefaultsStorage {
+  private static final Path FILE = Path.of("campaign_defaults.dcnf");
+  private static final Set<String> BUNDLED_MOD_IDS = Set.of("lod_core", "lod", "turn_order");
+
+  private CampaignConfigDefaultsStorage() { }
+
+  public static void load(final ConfigCollection configs) {
+    ConfigStorage.loadConfig(configs, ConfigStorageLocation.CAMPAIGN, FILE, CampaignConfigDefaultsStorage::manages, CampaignConfigDefaultsStorage::deserialize);
+  }
+
+  public static void save(final ConfigCollection configs) {
+    ConfigStorage.saveConfig(configs, ConfigStorageLocation.CAMPAIGN, FILE, CampaignConfigDefaultsStorage::manages, CampaignConfigDefaultsStorage::serialize);
+  }
+
+  public static boolean manages(final ConfigEntry<?> config) {
+    final RegistryId id = config.getRegistryId();
+    return config.storageLocation == ConfigStorageLocation.CAMPAIGN && config.hasEditControl() && id != null && BUNDLED_MOD_IDS.contains(id.modId());
+  }
+
+  private static byte[] serialize(final ConfigEntry<?> config, final Object value) {
+    final byte[] configValue = serializeConfigValue(config, value);
+    final FileData data = new ExpandableFileData(1);
+    final IntRef offset = new IntRef();
+    data.writeAscii(offset, typeSignature(config));
+    data.write(0, configValue, offset.get(), configValue.length);
+    offset.add(configValue.length);
+    return Arrays.copyOf(data.getBytes(), offset.get());
+  }
+
+  private static Object deserialize(final ConfigEntry<?> config, final byte[] value) {
+    final FileData data = new FileData(value);
+    final IntRef offset = new IntRef();
+    final String storedTypeSignature = data.readAscii(offset);
+    final String currentTypeSignature = typeSignature(config);
+
+    if(!storedTypeSignature.equals(currentTypeSignature)) {
+      throw new IllegalArgumentException("Incompatible config type " + storedTypeSignature + " for " + config.getRegistryId());
+    }
+
+    return deserializeConfigValue(config, data.slice(offset.get()).getBytes());
+  }
+
+  private static String typeSignature(final ConfigEntry<?> config) {
+    final Object defaultValue = config.getDefaultValue();
+    final String valueType = defaultValue == null ? "null" : defaultValue.getClass().getName();
+    return config.getClass().getName() + ':' + valueType;
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static byte[] serializeConfigValue(final ConfigEntry config, final Object value) {
+    return (byte[])config.serializer.apply(value);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static Object deserializeConfigValue(final ConfigEntry config, final byte[] value) {
+    return config.deserializer.apply(value);
+  }
+}

--- a/src/main/java/legend/game/saves/ConfigCollection.java
+++ b/src/main/java/legend/game/saves/ConfigCollection.java
@@ -1,5 +1,6 @@
 package legend.game.saves;
 
+import legend.game.modding.events.config.CampaignConfigUpdatedEvent;
 import legend.game.modding.events.config.ConfigUpdatedEvent;
 import legend.lodmod.LodMod;
 import org.legendofdragoon.modloader.ModContainer;
@@ -29,6 +30,10 @@ public class ConfigCollection {
     this.setConfigQuietly(config, value);
     config.onChange(this, oldValue, value);
     EVENTS.postEvent(new ConfigUpdatedEvent(config));
+
+    if(config.storageLocation == ConfigStorageLocation.CAMPAIGN) {
+      EVENTS.postEvent(new CampaignConfigUpdatedEvent(this, config));
+    }
   }
 
   /** Doesn't trigger onChange */

--- a/src/main/java/legend/game/saves/ConfigStorage.java
+++ b/src/main/java/legend/game/saves/ConfigStorage.java
@@ -3,6 +3,7 @@ package legend.game.saves;
 import legend.core.memory.types.IntRef;
 import legend.game.modding.coremod.CoreMod;
 import legend.game.modding.events.config.ConfigLoadedEvent;
+import legend.game.unpacker.ExpandableFileData;
 import legend.game.unpacker.FileData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -10,10 +11,15 @@ import org.legendofdragoon.modloader.registries.RegistryDelegate;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 import static legend.core.GameEngine.CONFIG;
 import static legend.core.GameEngine.EVENTS;
@@ -45,89 +51,105 @@ public final class ConfigStorage {
   }
 
   public static void saveConfig(final ConfigCollection configs, final ConfigStorageLocation location, final Path file) {
-    LOGGER.info("Saving config %s to %s", location, file);
+    saveConfig(configs, location, file, config -> true, ConfigStorage::serialize);
+  }
+
+  public static void loadConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final FileData data) {
+    loadConfig(configs, storageLocation, data, config -> true, ConfigStorage::deserialize, true);
+    EVENTS.postEvent(new ConfigLoadedEvent(configs, storageLocation));
+    RENDERER.setFrameSkipOption(CONFIG.getConfig(CoreMod.FRAME_SKIP_CONFIG.get()));
+  }
+
+  public static void saveConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final FileData data, final IntRef offset) {
+    saveConfig(configs, storageLocation, data, offset, config -> true, ConfigStorage::serialize);
+  }
+
+  static void loadConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final Path file, final Predicate<ConfigEntry<?>> filter, final BiFunction<ConfigEntry<?>, byte[], Object> deserializer) {
+    LOGGER.info("Loading filtered config %s from %s", storageLocation, file);
+
+    if(!Files.exists(file)) return;
 
     try {
-      Files.createDirectories(file.toAbsolutePath().getParent());
-    } catch(final IOException e) {
-      LOGGER.warn("Failed to create parent directories for config file %s", file);
+      loadConfig(configs, storageLocation, new FileData(Files.readAllBytes(file)), filter, deserializer, false);
+    } catch(final Throwable e) {
+      LOGGER.warn("Failed to load filtered config file %s", file);
       LOGGER.warn("Exception", e);
-      return;
     }
+  }
 
-    final FileData data = new FileData(new byte[100 * 1024]);
-    final IntRef size = new IntRef();
-    saveConfig(configs, location, data, size);
+  static void saveConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final Path file, final Predicate<ConfigEntry<?>> filter, final BiFunction<ConfigEntry<?>, Object, byte[]> serializer) {
+    LOGGER.info("Saving config %s to %s", storageLocation, file);
+
+    final FileData data = new ExpandableFileData(1);
+    final IntRef offset = new IntRef();
+    saveConfig(configs, storageLocation, data, offset, filter, serializer);
 
     try {
-      Files.write(file, data.slice(0, size.get()).getBytes());
+      writeAtomically(file, Arrays.copyOf(data.getBytes(), offset.get()));
     } catch(final IOException e) {
       LOGGER.warn("Failed to save config file %s", file);
       LOGGER.warn("Exception", e);
     }
   }
 
-  public static void loadConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final FileData data) {
-    int offset = 0;
+  private static void loadConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final FileData data, final Predicate<ConfigEntry<?>> filter, final BiFunction<ConfigEntry<?>, byte[], Object> deserializer, final boolean clearConfig) {
+    final IntRef offset = new IntRef();
 
-    configs.clearConfig(storageLocation);
+    if(clearConfig) configs.clearConfig(storageLocation);
 
     final int configCount = data.readInt(offset);
-    offset += 4;
 
     for(int configIndex = 0; configIndex < configCount; configIndex++) {
       final RegistryId configId = data.readRegistryId(offset);
-      offset += configId.toString().length() + 3;
+      final int configValueLength = data.readInt(offset);
+      final byte[] configValue = data.slice(offset.get(), configValueLength).getBytes();
+      offset.add(configValueLength);
+
+      if(configId == null) {
+        LOGGER.warn("Unknown config ID %s", configId);
+        continue;
+      }
 
       final RegistryDelegate<ConfigEntry<?>> delegate = REGISTRIES.config.getEntry(configId);
 
-      if(delegate.isValid()) {
-        //noinspection rawtypes
-        final ConfigEntry configEntry = delegate.get();
+      if(!delegate.isValid()) {
+        LOGGER.warn("Unknown config ID %s", configId);
+        continue;
+      }
 
-        final int configValueLength = data.readInt(offset);
-        offset += 4;
+      final ConfigEntry<?> configEntry = delegate.get();
 
-        final byte[] configValueRaw = data.slice(offset, configValueLength).getBytes();
-        offset += configValueLength;
+      if(configEntry.storageLocation != storageLocation || !filter.test(configEntry)) continue;
 
-        if(configEntry != null) {
-          if(configEntry.storageLocation == storageLocation) {
-            //noinspection unchecked
-            configs.setConfigQuietly(configEntry, configEntry.deserializer.apply(configValueRaw));
-          }
-        } else {
-          LOGGER.warn("Unknown config ID %s", configId);
-        }
-      } else {
-        LOGGER.warn("Unknown mod ID %s", configId);
-        final int configValueLength = data.readInt(offset);
-        offset += 4;
-        offset += configValueLength;
+      try {
+        setConfigQuietly(configs, configEntry, deserializer.apply(configEntry, configValue));
+      } catch(final Throwable e) {
+        LOGGER.warn("Ignoring invalid config ID %s", configId);
+        LOGGER.warn("Exception", e);
       }
     }
-
-    EVENTS.postEvent(new ConfigLoadedEvent(configs, storageLocation));
-    RENDERER.setFrameSkipOption(CONFIG.getConfig(CoreMod.FRAME_SKIP_CONFIG.get()));
   }
 
-  public static void saveConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final FileData data, final IntRef offset) {
+  private static void saveConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final FileData data, final IntRef offset, final Predicate<ConfigEntry<?>> filter, final BiFunction<ConfigEntry<?>, Object, byte[]> serializer) {
     final Map<RegistryId, byte[]> config = new HashMap<>();
 
     for(final RegistryId configId : REGISTRIES.config) {
-      //noinspection rawtypes
-      final ConfigEntry configEntry = REGISTRIES.config.getEntry(configId).get();
+      final ConfigEntry<?> configEntry = REGISTRIES.config.getEntry(configId).get();
 
-      if(configEntry.storageLocation == storageLocation) {
-        //noinspection unchecked
-        final Object value = configs.getConfig(configEntry);
+      if(configEntry.storageLocation != storageLocation || !filter.test(configEntry)) continue;
 
-        if(value != null) {
-          //noinspection unchecked
-          config.put(configId, (byte[])configEntry.serializer.apply(value));
-        } else {
-          LOGGER.warn("Unknown config ID %s", configId);
-        }
+      final Object value = configs.getConfig(configEntry);
+
+      if(value == null) {
+        LOGGER.warn("Unknown config ID %s", configId);
+        continue;
+      }
+
+      try {
+        config.put(configId, serializer.apply(configEntry, value));
+      } catch(final Throwable e) {
+        LOGGER.warn("Ignoring invalid config ID %s while saving", configId);
+        LOGGER.warn("Exception", e);
       }
     }
 
@@ -136,7 +158,45 @@ public final class ConfigStorage {
     for(final var entry : config.entrySet()) {
       data.writeRegistryId(offset, entry.getKey());
       data.writeInt(offset, entry.getValue().length);
-      data.write(0, entry.getValue(), offset, entry.getValue().length);
+      data.write(0, entry.getValue(), offset.get(), entry.getValue().length);
+      offset.add(entry.getValue().length);
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static byte[] serialize(final ConfigEntry config, final Object value) {
+    return (byte[])config.serializer.apply(value);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static Object deserialize(final ConfigEntry config, final byte[] value) {
+    return config.deserializer.apply(value);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static void setConfigQuietly(final ConfigCollection configs, final ConfigEntry config, final Object value) {
+    configs.setConfigQuietly(config, value);
+  }
+
+  private static void writeAtomically(final Path file, final byte[] data) throws IOException {
+    final Path absoluteFile = file.toAbsolutePath();
+    final Path parent = absoluteFile.getParent();
+    Path temporaryFile = null;
+
+    try {
+      Files.createDirectories(parent);
+      temporaryFile = Files.createTempFile(parent, absoluteFile.getFileName().toString(), ".tmp");
+      Files.write(temporaryFile, data);
+
+      try {
+        Files.move(temporaryFile, absoluteFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch(final AtomicMoveNotSupportedException e) {
+        Files.move(temporaryFile, absoluteFile, StandardCopyOption.REPLACE_EXISTING);
+      }
+
+      temporaryFile = null;
+    } finally {
+      if(temporaryFile != null) Files.deleteIfExists(temporaryFile);
     }
   }
 }

--- a/src/main/resources/lod_core/lang/en.lang
+++ b/src/main/resources/lod_core/lang/en.lang
@@ -255,6 +255,7 @@ lod_core.config.retail_font.label=Font
 lod_core.config.language.label=Language (WIP, Menu Only)
 lod_core.config.language.help=Language support is a work in progress and most of the game will still display in English
 lod_core.config.show_fps.label=Show FPS
+lod_core.config.remember_campaign_settings.label=Remember campaign settings
 
 # Shader config
 lod_core.config.shader_enable_crt.label=CRT Enabled


### PR DESCRIPTION
## Motivation

Campaign-specific settings previously reset to registered defaults whenever a new campaign was created. This was super annoying as 95% of my campaign preferences were always the same.

## Changes

- Adds a global toggle that remembers campaign settings for future campaigns
- Stores dynamic, type-checked snapshots while safely ignoring removed, renamed, incompatible, external-mod, or malformed entries
- Adds campaign configuration lifecycle events so mods can persist their settings and override restored defaults
  - The system does not save any mod stuff on its own and leaves that up to modders to deal with
  - Modders get an end of lifecycle snapshot and can overwrite any settings they want

## Other bugs fixed

- Restores remembered controls into the live input-binding table when creating a new campaign
- Resolves saved input actions against the current registry after mod reboot, fixing controls when loading existing campaigns (and new game transitions)
  - Have been wondering why control edits were not persisting into a new campaign load 

## QA
- https://streamable.com/d83v5v

## Notes
- Existing or previous campaigns do not get updated (could be a feature though: copy existing sticky config to current campain)
- Campaign saves are still authoritative for campaign loads
- Remember Campaign Config setting is on by default but can be turned off