### PR TITLE
Additions Modding

### DIFF
--- a/src/main/java/legend/game/additions/AdditionHitProperties10.java
+++ b/src/main/java/legend/game/additions/AdditionHitProperties10.java
@@ -60,6 +60,15 @@ public class AdditionHitProperties10 {
     this.sounds = sounds;
   }
 
+  /**
+   * Creates an independent copy of one addition hit.
+   *
+   * <p>All scalar properties and {@link #animationScale} are copied. The sound array and each
+   * {@link AdditionSound} entry are also copied, so callers may modify the new hit without changing
+   * the source hit.</p>
+   *
+   * @param other addition hit to copy
+   */
   public AdditionHitProperties10(final AdditionHitProperties10 other) {
     this(other.flags_00, other.totalFrames_01, other.overlayHitFrameOffset_02, other.totalSuccessFrames_03, other.damageMultiplier_04, other.sp_05, other.audioFile_06, other.isFinalHit_07, other.cameraMovementX_08, other.cameraMovementZ_09, other.cameraMovementTicks_0a, other.hitDistanceFromTarget_0b, other.framesToHitPosition_0c, other._0d, other.additionFailAnimationIndex_0e, other.overlayStartingFrameOffset_0f, copySounds(other.sounds));
     this.animationScale = other.animationScale;

--- a/src/main/java/legend/game/additions/AdditionHitProperties10.java
+++ b/src/main/java/legend/game/additions/AdditionHitProperties10.java
@@ -60,6 +60,19 @@ public class AdditionHitProperties10 {
     this.sounds = sounds;
   }
 
+  public AdditionHitProperties10(final AdditionHitProperties10 other) {
+    this(other.flags_00, other.totalFrames_01, other.overlayHitFrameOffset_02, other.totalSuccessFrames_03, other.damageMultiplier_04, other.sp_05, other.audioFile_06, other.isFinalHit_07, other.cameraMovementX_08, other.cameraMovementZ_09, other.cameraMovementTicks_0a, other.hitDistanceFromTarget_0b, other.framesToHitPosition_0c, other._0d, other.additionFailAnimationIndex_0e, other.overlayStartingFrameOffset_0f, copySounds(other.sounds));
+    this.animationScale = other.animationScale;
+  }
+
+  private static AdditionSound[] copySounds(final AdditionSound[] sounds) {
+    final AdditionSound[] copy = new AdditionSound[sounds.length];
+    for(int i = 0; i < sounds.length; i++) {
+      copy[i] = new AdditionSound(sounds[i].soundIndex, sounds[i].initialDelay);
+    }
+    return copy;
+  }
+
   public int get(final int index) {
     if(index == 100) {
       return this.animationScale;

--- a/src/main/java/legend/game/characters/AdditionMasteryUnlockCriterion.java
+++ b/src/main/java/legend/game/characters/AdditionMasteryUnlockCriterion.java
@@ -3,14 +3,12 @@ package legend.game.characters;
 import legend.game.additions.Addition;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
-import static legend.core.GameEngine.REGISTRIES;
-
 public class AdditionMasteryUnlockCriterion implements AdditionUnlockCriterion {
   @Override
   public boolean isUnlocked(final CharacterData2c character, final CharacterAdditionInfo additionInfo) {
     for(final RegistryId id : character.getAllAdditions()) {
       final CharacterAdditionInfo info = character.getAdditionInfo(id);
-      final Addition addition = REGISTRIES.additions.getEntry(id).get();
+      final Addition addition = character.resolveAddition(id);
 
       if(addition.countsTowardsMastery(character, info) && !addition.isComplete(character, info)) {
         return false;

--- a/src/main/java/legend/game/characters/CharacterData2c.java
+++ b/src/main/java/legend/game/characters/CharacterData2c.java
@@ -2,11 +2,13 @@ package legend.game.characters;
 
 import legend.core.lang.I18nText;
 import legend.core.lang.TextComponent;
+import legend.game.additions.Addition;
 import legend.game.additions.AdditionHits80;
 import legend.game.combat.bent.PlayerBattleEntity;
 import legend.game.inventory.CanEquip;
 import legend.game.inventory.Equipment;
 import legend.game.inventory.EquipmentTypes;
+import legend.game.modding.events.characters.ResolveAdditionEvent;
 import legend.game.modding.events.characters.ResolveCharacterElementEvent;
 import legend.game.types.EquipmentSlot;
 import legend.game.types.GameState52c;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static legend.core.GameEngine.EVENTS;
+import static legend.core.GameEngine.REGISTRIES;
 
 public class CharacterData2c {
   public static final int IN_PARTY = 0x1;
@@ -256,6 +259,12 @@ public class CharacterData2c {
 
   public CharacterAdditionInfo getAdditionInfo(final RegistryId id) {
     return this.additions.get(id);
+  }
+
+  public Addition resolveAddition(final RegistryId id) {
+    final Addition baseAddition = REGISTRIES.additions.getEntry(id).get();
+    final CharacterAdditionInfo additionInfo = this.getAdditionInfo(id);
+    return EVENTS.postEvent(new ResolveAdditionEvent(this, additionInfo, id, baseAddition)).addition;
   }
 
   public CharacterAdditionInfo addAddition(final RegistryId id, final CharacterAdditionInfo info) {

--- a/src/main/java/legend/game/characters/CharacterData2c.java
+++ b/src/main/java/legend/game/characters/CharacterData2c.java
@@ -261,6 +261,16 @@ public class CharacterData2c {
     return this.additions.get(id);
   }
 
+  /**
+   * Resolves the effective addition definition for this character.
+   *
+   * <p>The registered definition and this character's progression are supplied to a
+   * {@link ResolveAdditionEvent}. The event is posted on every call; callers must not assume the
+   * returned definition is cached or identical across resolutions.</p>
+   *
+   * @param id registry ID of the addition to resolve
+   * @return addition definition selected by the event listeners
+   */
   public Addition resolveAddition(final RegistryId id) {
     final Addition baseAddition = REGISTRIES.additions.getEntry(id).get();
     final CharacterAdditionInfo additionInfo = this.getAdditionInfo(id);

--- a/src/main/java/legend/game/combat/Battle.java
+++ b/src/main/java/legend/game/combat/Battle.java
@@ -114,6 +114,7 @@ import legend.game.modding.events.battle.EnemyRewardsEvent;
 import legend.game.modding.events.battle.LoadDeffEvent;
 import legend.game.modding.events.battle.LoadEnemyEvent;
 import legend.game.modding.events.battle.MonsterStatsEvent;
+import legend.game.modding.events.battle.ResolvePhysicalAttackStatusEvent;
 import legend.game.scripting.FlowControl;
 import legend.game.scripting.Param;
 import legend.game.scripting.RunningScript;
@@ -4379,16 +4380,13 @@ public class Battle extends EngineState<Battle> {
     if(script.params_20[1].get() != 0) {
       final BattleEntity27c bent = SCRIPTS.getObject(script.params_20[0].get(), BattleEntity27c.class);
 
-      final int charIndex = bent.charId_272;
-      final CharacterData2c charData = gameState_800babc8.charData_32c.get(charIndex);
-
-      if(charData.selectedAddition_19 == null) {
+      if(!(bent instanceof final PlayerBattleEntity player) || player.selectedAddition_58 == null) {
         //LAB_800cd200
         return FlowControl.CONTINUE;
       }
 
       //LAB_800cd208
-      final CharacterAdditionInfo additionInfo = charData.getAdditionInfo(charData.selectedAddition_19);
+      final CharacterAdditionInfo additionInfo = player.character.getAdditionInfo(player.selectedAddition_58);
       additionInfo.xp++;
     }
 
@@ -8409,7 +8407,7 @@ public class Battle extends EngineState<Battle> {
       player.dlevel_06 = player.character.dlevel_13;
       player.status_0e = player.character.getStatusAndFlags();
       player.selectedAddition_58 = player.character.selectedAddition_19;
-      player.addition = player.character.selectedAddition_19 != null ? REGISTRIES.additions.getEntry(player.character.selectedAddition_19).get() : null;
+      player.addition = player.character.selectedAddition_19 != null ? player.character.resolveAddition(player.character.selectedAddition_19) : null;
 
       player.equipment_11e.clear();
 
@@ -8795,13 +8793,18 @@ public class Battle extends EngineState<Battle> {
 
     final boolean isAttackerMonster = attacker instanceof MonsterBattleEntity;
 
-    final int effectChance = attacker.getStatusEffectChance(attackType);
+    int effectChance = attacker.getStatusEffectChance(attackType);
+    int statusType = attacker.getStatusEffectStatus(attackType);
+
+    if(attackType == AttackType.PHYSICAL && attacker instanceof final PlayerBattleEntity player) {
+      final ResolvePhysicalAttackStatusEvent event = EVENTS.postEvent(new ResolvePhysicalAttackStatusEvent(player, defender, player.selectedAddition_58, player.isAdditionCompletedSuccessfully(), effectChance, statusType));
+      effectChance = event.chance;
+      statusType = event.statusMask;
+    }
 
     //LAB_800f7e98
     int effect = -1;
     if(seed_800fa754.nextInt(100) < effectChance) {
-      final int statusType = attacker.getStatusEffectStatus(attackType);
-
       if((statusType & 0xff) != 0) {
         //LAB_800f7eec
         int statusIndex;

--- a/src/main/java/legend/game/combat/Battle.java
+++ b/src/main/java/legend/game/combat/Battle.java
@@ -5167,7 +5167,8 @@ public class Battle extends EngineState<Battle> {
     } else {
       //LAB_800d3dc0
       final AdditionNameTextEffect1c additionStruct = new AdditionNameTextEffect1c();
-      final Addition addition = REGISTRIES.additions.getEntry(gameState_800babc8.charData_32c.get(script.params_20[0].get()).selectedAddition_19).get();
+      final CharacterData2c character = gameState_800babc8.charData_32c.get(script.params_20[0].get());
+      final Addition addition = character.resolveAddition(character.selectedAddition_19);
       final ScriptState<AdditionNameTextEffect1c> state = SCRIPTS.allocateScriptState("AdditionNameTextEffect1c", additionStruct);
       state.loadScriptFile(doNothingScript_8004f650);
       state.setTicker((s, effect) -> additionStruct.tickAdditionNameEffect(s, this._800faa9d));

--- a/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
+++ b/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
@@ -14,6 +14,7 @@ import legend.game.inventory.Equipment;
 import legend.game.inventory.SpellStats0c;
 import legend.game.modding.coremod.CoreMod;
 import legend.game.modding.events.battle.ArcherSpEvent;
+import legend.game.modding.events.battle.ResolvePhysicalAttackElementsEvent;
 import legend.game.modding.events.battle.SpellStatsEvent;
 import legend.game.scripting.Param;
 import legend.game.scripting.ScriptFile;
@@ -171,7 +172,17 @@ public class PlayerBattleEntity extends BattleEntity27c {
 
   @Override
   public ElementSet getAttackElements() {
-    return this.equipmentAttackElements_1c;
+    return EVENTS.postEvent(new ResolvePhysicalAttackElementsEvent(this, this.equipmentAttackElements_1c)).elements;
+  }
+
+  public boolean isAdditionCompletedSuccessfully() {
+    if(this.isDragoon() || this.selectedAddition_58 == null || this.additionHits_56 <= 0) return false;
+
+    // The addition hit count includes the physical hit currently being resolved.
+    final int hitIndex = this.additionHits_56 - 1;
+    if(hitIndex >= this.getAdditionHitCount()) return false;
+
+    return battlePreloadedEntities_1f8003f4.getHit(this.typeBentSlot_276, hitIndex).isFinalHit_07 != 0;
   }
 
   @Override
@@ -516,7 +527,6 @@ public class PlayerBattleEntity extends BattleEntity27c {
       case DRAGOON_ATTACK_SOUNDS -> out.set(this.getDragoonAttackSounds());
       case ARCHER_SP -> out.set(this.getArcherSp());
       case ADDITION_HIT_COUNT -> out.set(this.getAdditionHitCount());
-
       case GUARD_HEAL -> out.set(this.stats.getStat(GUARD_HEAL_STAT.get()).get());
       case GUARD_HEAL_RAW -> out.set(this.stats.getStat(GUARD_HEAL_STAT.get()).getRaw());
 
@@ -539,7 +549,6 @@ public class PlayerBattleEntity extends BattleEntity27c {
       case CURRENT_MP -> this.stats.getStat(MP_STAT.get()).setCurrent(value);
 
       case ADDITION_HITS -> this.additionHits_56 = value;
-
       case DRAGOON_ATTACK -> this.stats.getStat(DRAGOON_ATTACK_STAT.get()).setRaw(value);
       case DRAGOON_MAGIC -> this.stats.getStat(DRAGOON_MAGIC_ATTACK_STAT.get()).setRaw(value);
       case DRAGOON_DEFENCE -> this.stats.getStat(DRAGOON_DEFENSE_STAT.get()).setRaw(value);

--- a/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
+++ b/src/main/java/legend/game/combat/bent/PlayerBattleEntity.java
@@ -175,6 +175,15 @@ public class PlayerBattleEntity extends BattleEntity27c {
     return EVENTS.postEvent(new ResolvePhysicalAttackElementsEvent(this, this.equipmentAttackElements_1c)).elements;
   }
 
+  /**
+   * Reports whether the physical hit currently being resolved reached the selected addition's
+   * final hit.
+   *
+   * <p>Dragoon attacks, attacks without a selected addition, and invalid hit positions return
+   * {@code false}.</p>
+   *
+   * @return {@code true} when the current non-Dragoon addition hit is marked as its final hit
+   */
   public boolean isAdditionCompletedSuccessfully() {
     if(this.isDragoon() || this.selectedAddition_58 == null || this.additionHits_56 <= 0) return false;
 

--- a/src/main/java/legend/game/combat/environment/BattlePreloadedEntities_18cb0.java
+++ b/src/main/java/legend/game/combat/environment/BattlePreloadedEntities_18cb0.java
@@ -12,7 +12,6 @@ import legend.game.types.McqHeader;
 import java.util.ArrayList;
 import java.util.List;
 
-import static legend.core.GameEngine.REGISTRIES;
 import static legend.game.Scus94491BpeSegment_8006.battleState_8006e398;
 import static legend.game.Scus94491BpeSegment_800b.gameState_800babc8;
 import static legend.game.combat.bent.BattleEntity27c.FLAG_DRAGOON;
@@ -37,8 +36,9 @@ public class BattlePreloadedEntities_18cb0 {
 
     //LAB_800c74fc
     final CharacterData2c character = gameState_800babc8.getCharacterBySlot(charSlot);
-    final CharacterAdditionInfo additionInfo = character.getAdditionInfo(character.selectedAddition_19);
-    return REGISTRIES.additions.getEntry(character.selectedAddition_19).get().getHit(character, additionInfo, hitNum);
+    final var player = battleState_8006e398.playerBents_e40.get(charSlot).innerStruct_00;
+    final CharacterAdditionInfo additionInfo = character.getAdditionInfo(player.selectedAddition_58);
+    return player.addition.getHit(character, additionInfo, hitNum);
   }
 
   public int getHitCount(final int charSlot) {
@@ -48,8 +48,9 @@ public class BattlePreloadedEntities_18cb0 {
 
     //LAB_800c74fc
     final CharacterData2c character = gameState_800babc8.getCharacterBySlot(charSlot);
-    final CharacterAdditionInfo additionInfo = character.getAdditionInfo(character.selectedAddition_19);
-    return REGISTRIES.additions.getEntry(character.selectedAddition_19).get().getHitCount(character, additionInfo);
+    final var player = battleState_8006e398.playerBents_e40.get(charSlot).innerStruct_00;
+    final CharacterAdditionInfo additionInfo = character.getAdditionInfo(player.selectedAddition_58);
+    return player.addition.getHitCount(character, additionInfo);
   }
 
   @Method(0x800c7488L)

--- a/src/main/java/legend/game/combat/ui/AdditionListMenu.java
+++ b/src/main/java/legend/game/combat/ui/AdditionListMenu.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static legend.core.GameEngine.CONFIG;
-import static legend.core.GameEngine.REGISTRIES;
 import static legend.game.Text.renderText;
 import static legend.lodmod.LodConfig.UI_BACKGROUND_COLOUR;
 
@@ -56,7 +55,7 @@ public class AdditionListMenu extends ListMenu {
   protected void drawListEntry(final int index, final int x, final int y, final int trim) {
     final RegistryId additionId = this.additionIds.get(index);
     final CharacterAdditionInfo additionInfo = this.player_08.character.getAdditionInfo(additionId);
-    final Addition addition = REGISTRIES.additions.getEntry(additionId).get();
+    final Addition addition = this.player_08.character.resolveAddition(additionId);
 
     this.fontOptions.trim(trim);
     this.fontOptions.horizontalAlign(HorizontalAlign.LEFT);
@@ -85,7 +84,7 @@ public class AdditionListMenu extends ListMenu {
   protected void onUse(final int index) {
     this.player_08.combatant_144.mrg_04 = null;
     this.player_08.character.selectedAddition_19 = this.additionIds.get(index);
-    this.player_08.addition = REGISTRIES.additions.getEntry(this.player_08.character.selectedAddition_19).get();
+    this.player_08.addition = this.player_08.character.resolveAddition(this.player_08.character.selectedAddition_19);
     this.hud.battle.loadAttackAnimations(this.player_08.combatant_144);
     this.flags_02 &= ~0x8;
     this.menuState_00 = 8;
@@ -115,7 +114,7 @@ public class AdditionListMenu extends ListMenu {
       if((this.flags_02 & 0x40) != 0) {
         final int listIndex = this.listScroll_1e + this.listIndex_24;
         final RegistryId additionId = this.additionIds.get(listIndex);
-        final Addition addition = REGISTRIES.additions.getEntry(additionId).get();
+      final Addition addition = this.player_08.character.resolveAddition(additionId);
         final CharacterAdditionInfo additionInfo = this.player_08.character.getAdditionInfo(additionId);
         final int damage = addition.getDamage(this.player_08.character, additionInfo);
         final int sp = addition.getSp(this.player_08.character, additionInfo);

--- a/src/main/java/legend/game/inventory/screens/AdditionsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/AdditionsScreen.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Set;
 
 import static legend.core.GameEngine.PLATFORM;
-import static legend.core.GameEngine.REGISTRIES;
 import static legend.game.FullScreenEffects.startFadeEffect;
 import static legend.game.Menus.deallocateRenderables;
 import static legend.game.Menus.unloadRenderable;
@@ -164,7 +163,7 @@ public class AdditionsScreen extends MenuScreen {
 
       for(int i = 0; i < Math.min(this.additionIds.size() - this.additionScroll, ADDITION_SLOTS); i++) {
         final RegistryId additionId = this.additionIds.get(i + this.additionScroll);
-        final Addition addition = REGISTRIES.additions.getEntry(additionId).get();
+      final Addition addition = charData.resolveAddition(additionId);
         final int y = this.getAdditionSlotY(i);
 
         renderText(addition.getName(), 33, y - 2, !additionId.equals(selectedAddition) ? UI_TEXT : UI_TEXT_SELECTED);

--- a/src/main/java/legend/game/inventory/screens/PostBattleScreen.java
+++ b/src/main/java/legend/game/inventory/screens/PostBattleScreen.java
@@ -613,7 +613,7 @@ public class PostBattleScreen extends MenuScreen {
     for(final LevelUpActions.Entry<?> entry : results) {
       if(entry.action instanceof final UnlockAdditionLevelUpAction unlockAddition) {
         final UnlockAdditionLevelUpActionOptions options = unlockAddition.cast(entry.options);
-        this.additionsUnlocked_8011e1b8.computeIfAbsent(character, k -> new ArrayList<>()).add(REGISTRIES.additions.getEntry(options.additionId).get());
+        this.additionsUnlocked_8011e1b8.computeIfAbsent(character, k -> new ArrayList<>()).add(character.resolveAddition(options.additionId));
       }
 
       if(entry.action instanceof final UnlockSpellLevelUpAction unlockSpell) {

--- a/src/main/java/legend/game/inventory/screens/PostBattleScreen.java
+++ b/src/main/java/legend/game/inventory/screens/PostBattleScreen.java
@@ -167,7 +167,7 @@ public class PostBattleScreen extends MenuScreen {
 
             for(final RegistryId additionId : character.getAllAdditions()) {
               final CharacterAdditionInfo additionInfo = character.getAdditionInfo(additionId);
-              final Addition addition = REGISTRIES.additions.getEntry(additionId).get();
+              final Addition addition = character.resolveAddition(additionId);
 
               while(additionInfo.level < addition.getMaxLevel(character, additionInfo) && additionInfo.xp >= addition.getXpToNextLevel(character, additionInfo)) {
                 additionInfo.level++;

--- a/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackElementsEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackElementsEvent.java
@@ -4,11 +4,30 @@ import legend.game.characters.ElementSet;
 import legend.game.combat.bent.PlayerBattleEntity;
 import org.legendofdragoon.modloader.events.Event;
 
+/**
+ * Fired when the element set for a player's physical attack is requested.
+ *
+ * <p>{@link #baseElements} and {@link #elements} are independent defensive copies. Listeners may
+ * add, remove, clear, or replace the contents of {@code elements}; that mutated set is returned to
+ * the requester. Mutating {@code elements} does not change {@code baseElements} or the attacker's
+ * equipment element set.</p>
+ */
 public class ResolvePhysicalAttackElementsEvent extends Event {
+  /** The player making the physical attack. */
   public final PlayerBattleEntity attacker;
+
+  /** Snapshot of the attack elements before listener changes. */
   public final ElementSet baseElements;
+
+  /** Mutable attack-element result returned after the event. */
   public final ElementSet elements;
 
+  /**
+   * Creates a physical-attack element-resolution request.
+   *
+   * @param attacker player making the physical attack
+   * @param baseElements attack elements used to initialize independent base and result snapshots
+   */
   public ResolvePhysicalAttackElementsEvent(final PlayerBattleEntity attacker, final ElementSet baseElements) {
     if(attacker == null) {
       throw new IllegalArgumentException("Physical attack element attacker cannot be null");

--- a/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackElementsEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackElementsEvent.java
@@ -1,0 +1,24 @@
+package legend.game.modding.events.battle;
+
+import legend.game.characters.ElementSet;
+import legend.game.combat.bent.PlayerBattleEntity;
+import org.legendofdragoon.modloader.events.Event;
+
+public class ResolvePhysicalAttackElementsEvent extends Event {
+  public final PlayerBattleEntity attacker;
+  public final ElementSet baseElements;
+  public final ElementSet elements;
+
+  public ResolvePhysicalAttackElementsEvent(final PlayerBattleEntity attacker, final ElementSet baseElements) {
+    if(attacker == null) {
+      throw new IllegalArgumentException("Physical attack element attacker cannot be null");
+    }
+    if(baseElements == null) {
+      throw new IllegalArgumentException("Physical attack base elements cannot be null");
+    }
+
+    this.attacker = attacker;
+    this.baseElements = new ElementSet().set(baseElements);
+    this.elements = new ElementSet().set(baseElements);
+  }
+}

--- a/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackStatusEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackStatusEvent.java
@@ -1,0 +1,38 @@
+package legend.game.modding.events.battle;
+
+import legend.game.combat.bent.BattleEntity27c;
+import legend.game.combat.bent.PlayerBattleEntity;
+import org.legendofdragoon.modloader.events.Event;
+import org.legendofdragoon.modloader.registries.RegistryId;
+
+import javax.annotation.Nullable;
+
+public class ResolvePhysicalAttackStatusEvent extends Event {
+  public final PlayerBattleEntity attacker;
+  public final BattleEntity27c defender;
+  @Nullable
+  public final RegistryId additionId;
+  public final boolean additionCompletedSuccessfully;
+  public final int baseChance;
+  public final int baseStatusMask;
+  public int chance;
+  public int statusMask;
+
+  public ResolvePhysicalAttackStatusEvent(final PlayerBattleEntity attacker, final BattleEntity27c defender, @Nullable final RegistryId additionId, final boolean additionCompletedSuccessfully, final int baseChance, final int baseStatusMask) {
+    if(attacker == null) {
+      throw new IllegalArgumentException("Physical attack status attacker cannot be null");
+    }
+    if(defender == null) {
+      throw new IllegalArgumentException("Physical attack status defender cannot be null");
+    }
+
+    this.attacker = attacker;
+    this.defender = defender;
+    this.additionId = additionId;
+    this.additionCompletedSuccessfully = additionCompletedSuccessfully;
+    this.baseChance = baseChance;
+    this.baseStatusMask = baseStatusMask;
+    this.chance = baseChance;
+    this.statusMask = baseStatusMask;
+  }
+}

--- a/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackStatusEvent.java
+++ b/src/main/java/legend/game/modding/events/battle/ResolvePhysicalAttackStatusEvent.java
@@ -7,17 +7,57 @@ import org.legendofdragoon.modloader.registries.RegistryId;
 
 import javax.annotation.Nullable;
 
+/**
+ * Fired before the status chance roll for each player physical attack.
+ *
+ * <p>Listeners may replace {@link #chance} and {@link #statusMask}; those values are used for the
+ * pending roll and status selection. The base values remain available for comparison.</p>
+ */
 public class ResolvePhysicalAttackStatusEvent extends Event {
+  /** The player making the physical attack. */
   public final PlayerBattleEntity attacker;
+
+  /** The battle entity receiving the physical attack. */
   public final BattleEntity27c defender;
+
+  /** The selected addition ID, or {@code null} when no addition is active. */
   @Nullable
   public final RegistryId additionId;
+
+  /** Whether this attack reached the selected non-Dragoon addition's final hit. */
   public final boolean additionCompletedSuccessfully;
+
+  /** Status chance supplied by the attacker before listener changes. */
   public final int baseChance;
+
+  /** Status bits supplied by the attacker before listener changes. */
   public final int baseStatusMask;
+
+  /**
+   * Percent chance used for the pending status roll.
+   *
+   * <p>This initially equals {@link #baseChance}. Listeners may assign a replacement.</p>
+   */
   public int chance;
+
+  /**
+   * Status bits used when the chance roll succeeds.
+   *
+   * <p>This initially equals {@link #baseStatusMask}. Listeners may assign a replacement.</p>
+   */
   public int statusMask;
 
+  /**
+   * Creates a physical-attack status-resolution request.
+   *
+   * @param attacker player making the physical attack
+   * @param defender battle entity receiving the physical attack
+   * @param additionId selected addition ID, or {@code null} when no addition is active
+   * @param additionCompletedSuccessfully whether this attack reached the selected non-Dragoon
+   *                                       addition's final hit
+   * @param baseChance status chance used as the initial result
+   * @param baseStatusMask status bits used as the initial result
+   */
   public ResolvePhysicalAttackStatusEvent(final PlayerBattleEntity attacker, final BattleEntity27c defender, @Nullable final RegistryId additionId, final boolean additionCompletedSuccessfully, final int baseChance, final int baseStatusMask) {
     if(attacker == null) {
       throw new IllegalArgumentException("Physical attack status attacker cannot be null");

--- a/src/main/java/legend/game/modding/events/characters/ResolveAdditionEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/ResolveAdditionEvent.java
@@ -1,0 +1,36 @@
+package legend.game.modding.events.characters;
+
+import legend.game.additions.Addition;
+import legend.game.characters.CharacterAdditionInfo;
+import legend.game.characters.CharacterData2c;
+import org.legendofdragoon.modloader.events.Event;
+import org.legendofdragoon.modloader.registries.RegistryId;
+
+public class ResolveAdditionEvent extends Event {
+  public final CharacterData2c character;
+  public final CharacterAdditionInfo additionInfo;
+  public final RegistryId additionId;
+  public final Addition baseAddition;
+  public Addition addition;
+
+  public ResolveAdditionEvent(final CharacterData2c character, final CharacterAdditionInfo additionInfo, final RegistryId additionId, final Addition baseAddition) {
+    if(character == null) {
+      throw new IllegalArgumentException("Addition character cannot be null");
+    }
+    if(additionInfo == null) {
+      throw new IllegalArgumentException("Addition info cannot be null");
+    }
+    if(additionId == null) {
+      throw new IllegalArgumentException("Addition ID cannot be null");
+    }
+    if(baseAddition == null) {
+      throw new IllegalArgumentException("Base addition cannot be null");
+    }
+
+    this.character = character;
+    this.additionInfo = additionInfo;
+    this.additionId = additionId;
+    this.baseAddition = baseAddition;
+    this.addition = baseAddition;
+  }
+}

--- a/src/main/java/legend/game/modding/events/characters/ResolveAdditionEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/ResolveAdditionEvent.java
@@ -6,13 +6,42 @@ import legend.game.characters.CharacterData2c;
 import org.legendofdragoon.modloader.events.Event;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
+/**
+ * Fired whenever an addition definition is resolved for a player character.
+ *
+ * <p>This includes battle setup, progression, animation loading, and menu display, so the event
+ * may be fired repeatedly for the same character and addition. Listeners may replace
+ * {@link #addition} with the definition the requester should use. The other fields provide
+ * context and are not returned as event results.</p>
+ */
 public class ResolveAdditionEvent extends Event {
+  /** The character for whom the addition is being resolved. */
   public final CharacterData2c character;
+
+  /** The character's current progression and unlock state for this addition. */
   public final CharacterAdditionInfo additionInfo;
+
+  /** The registry ID of the requested addition. */
   public final RegistryId additionId;
+
+  /** The registered addition definition before any listener-provided replacement. */
   public final Addition baseAddition;
+
+  /**
+   * The addition definition returned to the requester after the event.
+   *
+   * <p>This initially references {@link #baseAddition}. Listeners may assign a replacement.</p>
+   */
   public Addition addition;
 
+  /**
+   * Creates an addition-resolution request.
+   *
+   * @param character character for whom the addition is being resolved
+   * @param additionInfo character progression and unlock state for the requested addition
+   * @param additionId registry ID of the requested addition
+   * @param baseAddition registered addition definition used as the initial result
+   */
   public ResolveAdditionEvent(final CharacterData2c character, final CharacterAdditionInfo additionInfo, final RegistryId additionId, final Addition baseAddition) {
     if(character == null) {
       throw new IllegalArgumentException("Addition character cannot be null");

--- a/src/main/java/legend/game/modding/events/characters/ResolveCharacterAdditionSaveEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/ResolveCharacterAdditionSaveEvent.java
@@ -10,8 +10,19 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Fired immediately before a character's selected addition and addition progression are saved.
+ *
+ * <p>The event starts with defensive copies of the character's current addition state. Listeners
+ * may call {@link #resolve(RegistryId, Map)} to provide a different save projection without
+ * mutating the live character. The projected selected addition and progression returned by this
+ * event are written to the save.</p>
+ */
 public class ResolveCharacterAdditionSaveEvent extends Event {
+  /** The character whose addition state is being saved. */
   public final CharacterData2c character;
+
+  /** The character's selected addition before listener changes, or {@code null} when unselected. */
   @Nullable
   public final RegistryId baseSelectedAddition;
 
@@ -20,6 +31,11 @@ public class ResolveCharacterAdditionSaveEvent extends Event {
   private RegistryId selectedAddition;
   private Map<RegistryId, CharacterAdditionInfo> additions;
 
+  /**
+   * Creates a character-addition save projection from the character's current state.
+   *
+   * @param character character whose addition state is being saved
+   */
   public ResolveCharacterAdditionSaveEvent(final CharacterData2c character) {
     if(character == null) {
       throw new IllegalArgumentException("Addition save character cannot be null");
@@ -32,19 +48,52 @@ public class ResolveCharacterAdditionSaveEvent extends Event {
     this.additions = copyAdditions(this.baseAdditions);
   }
 
+  /**
+   * Returns the selected addition currently projected for the save.
+   *
+   * @return selected addition ID, or {@code null} when the save should contain no selection
+   */
   @Nullable
   public RegistryId getSelectedAddition() {
     return this.selectedAddition;
   }
 
+  /**
+   * Returns a defensive snapshot of every assigned addition before listener changes.
+   *
+   * <p>The map is unmodifiable. Its {@link CharacterAdditionInfo} values are copies, so changing a
+   * value does not modify the event or live character.</p>
+   *
+   * @return unmodifiable base addition-state snapshot keyed by assigned addition ID
+   */
   public Map<RegistryId, CharacterAdditionInfo> getBaseAdditions() {
     return copyAdditions(this.baseAdditions);
   }
 
+  /**
+   * Returns a defensive snapshot of the addition state currently projected for the save.
+   *
+   * <p>The map is unmodifiable. To change the projection, copy this map and its values as needed,
+   * then pass the completed map to {@link #resolve(RegistryId, Map)}.</p>
+   *
+   * @return unmodifiable projected addition state keyed by assigned addition ID
+   */
   public Map<RegistryId, CharacterAdditionInfo> getAdditions() {
     return copyAdditions(this.additions);
   }
 
+  /**
+   * Replaces the selected addition and progression projected for the save.
+   *
+   * <p>The map must contain exactly the character's assigned addition IDs and no null keys or
+   * values. A non-null selected addition must be one of those IDs. The accepted map and each
+   * {@link CharacterAdditionInfo} value are defensively copied.</p>
+   *
+   * @param selectedAddition selected addition to write, or {@code null} to save no selection
+   * @param additions complete projected progression keyed by assigned addition ID
+   * @throws IllegalArgumentException if the map is null, contains different addition IDs, contains
+   *                                  a null key or value, or omits a non-null selection
+   */
   public void resolve(@Nullable final RegistryId selectedAddition, final Map<RegistryId, CharacterAdditionInfo> additions) {
     if(additions == null) {
       throw new IllegalArgumentException("Resolved addition save data cannot be null");

--- a/src/main/java/legend/game/modding/events/characters/ResolveCharacterAdditionSaveEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/ResolveCharacterAdditionSaveEvent.java
@@ -1,0 +1,86 @@
+package legend.game.modding.events.characters;
+
+import legend.game.characters.CharacterAdditionInfo;
+import legend.game.characters.CharacterData2c;
+import org.legendofdragoon.modloader.events.Event;
+import org.legendofdragoon.modloader.registries.RegistryId;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ResolveCharacterAdditionSaveEvent extends Event {
+  public final CharacterData2c character;
+  @Nullable
+  public final RegistryId baseSelectedAddition;
+
+  private final Map<RegistryId, CharacterAdditionInfo> baseAdditions;
+  @Nullable
+  private RegistryId selectedAddition;
+  private Map<RegistryId, CharacterAdditionInfo> additions;
+
+  public ResolveCharacterAdditionSaveEvent(final CharacterData2c character) {
+    if(character == null) {
+      throw new IllegalArgumentException("Addition save character cannot be null");
+    }
+
+    this.character = character;
+    this.baseSelectedAddition = character.selectedAddition_19;
+    this.baseAdditions = copyAdditions(character);
+    this.selectedAddition = this.baseSelectedAddition;
+    this.additions = copyAdditions(this.baseAdditions);
+  }
+
+  @Nullable
+  public RegistryId getSelectedAddition() {
+    return this.selectedAddition;
+  }
+
+  public Map<RegistryId, CharacterAdditionInfo> getBaseAdditions() {
+    return copyAdditions(this.baseAdditions);
+  }
+
+  public Map<RegistryId, CharacterAdditionInfo> getAdditions() {
+    return copyAdditions(this.additions);
+  }
+
+  public void resolve(@Nullable final RegistryId selectedAddition, final Map<RegistryId, CharacterAdditionInfo> additions) {
+    if(additions == null) {
+      throw new IllegalArgumentException("Resolved addition save data cannot be null");
+    }
+
+    if(!additions.keySet().equals(this.baseAdditions.keySet())) {
+      throw new IllegalArgumentException("Resolved addition save IDs must match the character's assigned additions");
+    }
+
+    for(final Map.Entry<RegistryId, CharacterAdditionInfo> entry : additions.entrySet()) {
+      if(entry.getKey() == null || entry.getValue() == null) {
+        throw new IllegalArgumentException("Resolved addition save IDs and info cannot be null");
+      }
+    }
+
+    if(selectedAddition != null && !additions.containsKey(selectedAddition)) {
+      throw new IllegalArgumentException("Resolved selected addition must be assigned to the character");
+    }
+
+    this.selectedAddition = selectedAddition;
+    this.additions = copyAdditions(additions);
+  }
+
+  private static Map<RegistryId, CharacterAdditionInfo> copyAdditions(final CharacterData2c character) {
+    final Map<RegistryId, CharacterAdditionInfo> additions = new LinkedHashMap<>();
+    for(final RegistryId additionId : character.getAllAdditions()) {
+      additions.put(additionId, new CharacterAdditionInfo(character.getAdditionInfo(additionId)));
+    }
+    return Collections.unmodifiableMap(additions);
+  }
+
+  private static Map<RegistryId, CharacterAdditionInfo> copyAdditions(final Map<RegistryId, CharacterAdditionInfo> source) {
+    final Map<RegistryId, CharacterAdditionInfo> additions = new LinkedHashMap<>();
+    for(final Map.Entry<RegistryId, CharacterAdditionInfo> entry : source.entrySet()) {
+      additions.put(entry.getKey(), new CharacterAdditionInfo(entry.getValue()));
+    }
+    return Collections.unmodifiableMap(additions);
+  }
+}

--- a/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
+++ b/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
@@ -26,6 +26,7 @@ import legend.game.modding.events.characters.PostCharacterDragoonLevelUpEvent;
 import legend.game.modding.events.characters.PostCharacterLevelUpEvent;
 import legend.game.modding.events.characters.PreCharacterDragoonLevelUpEvent;
 import legend.game.modding.events.characters.PreCharacterLevelUpEvent;
+import legend.game.modding.events.characters.ResolveCharacterAdditionSaveEvent;
 import legend.game.saves.SavedCharacter;
 import legend.game.saves.SeveredSavedCharacterV2;
 import legend.game.textures.Image;
@@ -41,7 +42,6 @@ import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static legend.core.GameEngine.EVENTS;
@@ -168,16 +168,18 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
     }
     tag.set("equipment", equipsTag);
 
-    if(character.selectedAddition_19 != null) {
-      tag.set("selectedAdditionId", new RegistryIdTag(character.selectedAddition_19));
+    final ResolveCharacterAdditionSaveEvent additionSave = EVENTS.postEvent(new ResolveCharacterAdditionSaveEvent(character));
+    if(additionSave.getSelectedAddition() != null) {
+      tag.set("selectedAdditionId", new RegistryIdTag(additionSave.getSelectedAddition()));
     }
 
-    final Set<RegistryId> additionIds = character.getAllAdditions();
+    final var additions = additionSave.getAdditions();
     final ListTag additionsTag = new ListTag();
 
-    for(final RegistryId additionId : additionIds) {
+    for(final var entry : additions.entrySet()) {
+      final RegistryId additionId = entry.getKey();
       final MapTag additionTag = new MapTag();
-      final CharacterAdditionInfo info = character.getAdditionInfo(additionId);
+      final CharacterAdditionInfo info = entry.getValue();
       additionTag.set("additionId", new RegistryIdTag(additionId));
       additionTag.set("unlockState", new EnumTag(info.getUnlockState()));
       additionTag.set("unlockTimestamp", new IntTag(info.getUnlockTimestamp()));

--- a/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
+++ b/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
@@ -354,7 +354,7 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
   }
 
   public CompletableFuture<List<FileData>> loadHumanAttackAnimations(final CharacterData2c character, final  PlayerBattleEntity bent) {
-    return REGISTRIES.additions.getEntry(character.selectedAddition_19).get().loadAnimations(character, character.getAdditionInfo(character.selectedAddition_19));
+    return character.resolveAddition(character.selectedAddition_19).loadAnimations(character, character.getAdditionInfo(character.selectedAddition_19));
   }
 
   public abstract CompletableFuture<List<FileData>> loadDragoonAttackAnimations(final CharacterData2c character, final PlayerBattleEntity bent);


### PR DESCRIPTION
sharing for others
still testing / cleaning implementation

update desc soonTM

main features
- elemental assignment to additions
- status assignment to additions
- randomize unlock status, damage, sp -> level/xp additions still tied to campaign
- hit timings configurable
- support any valid additions in the registry

qa
<img width="1477" height="1084" alt="image" src="https://github.com/user-attachments/assets/f2f62bf8-82c2-4b8e-a513-892804e130bc" />
<img width="1474" height="1108" alt="image" src="https://github.com/user-attachments/assets/03909ec4-745f-4a69-aabb-239b183a17fe" />
