### PR TITLE
Fix XA playback native decoder use after free

### DIFF
--- a/src/main/java/legend/core/audio/AudioSource.java
+++ b/src/main/java/legend/core/audio/AudioSource.java
@@ -92,7 +92,7 @@ public abstract class AudioSource {
   }
 
   protected void handleProcessedBuffers() {
-    if(this.bufferIndex < this.buffers.length - 1) {
+    if(this.isInitialized() && this.bufferIndex < this.buffers.length - 1) {
       alGetSourcei(this.sourceId, AL_BUFFERS_PROCESSED, this.tmp);
       final int processedBufferCount = this.tmp.get(0);
 

--- a/src/main/java/legend/core/audio/AudioSource.java
+++ b/src/main/java/legend/core/audio/AudioSource.java
@@ -117,7 +117,7 @@ public abstract class AudioSource {
 
   protected void bufferOutput(final int format, final ByteBuffer buffer, final int sampleRate) {
     synchronized(this) {
-      if(this.bufferIndex >= 0) {
+      if(this.isInitialized() && this.bufferIndex >= 0) {
         final int bufferId = this.buffers[this.bufferIndex--];
         alBufferData(bufferId, format, buffer, sampleRate);
         alSourceQueueBuffers(this.sourceId, bufferId);
@@ -127,7 +127,7 @@ public abstract class AudioSource {
 
   protected void bufferOutput(final int format, final short[] buffer, final int sampleRate) {
     synchronized(this) {
-      if(this.bufferIndex >= 0) {
+      if(this.isInitialized() && this.bufferIndex >= 0) {
         final int bufferId = this.buffers[this.bufferIndex--];
         alBufferData(bufferId, format, buffer, sampleRate);
         alSourceQueueBuffers(this.sourceId, bufferId);
@@ -137,7 +137,7 @@ public abstract class AudioSource {
 
   protected void bufferOutput(final int format, final float[] buffer, final int sampleRate) {
     synchronized(this) {
-      if(this.bufferIndex >= 0) {
+      if(this.isInitialized() && this.bufferIndex >= 0) {
         final int bufferId = this.buffers[this.bufferIndex--];
         alBufferData(bufferId, format, buffer, sampleRate);
         alSourceQueueBuffers(this.sourceId, bufferId);
@@ -171,6 +171,12 @@ public abstract class AudioSource {
 
   /** NOTE: this method will return the play time of the current buffer, so if you're using more than one buffer it's likely not going to return what you expect */
   public float getPosition() {
-    return alGetSourcef(this.sourceId, AL_SEC_OFFSET);
+    synchronized(this) {
+      if(!this.isInitialized()) {
+        return 0.0f;
+      }
+
+      return alGetSourcef(this.sourceId, AL_SEC_OFFSET);
+    }
   }
 }

--- a/src/main/java/legend/core/audio/AudioThread.java
+++ b/src/main/java/legend/core/audio/AudioThread.java
@@ -53,6 +53,7 @@ public final class AudioThread implements Runnable {
   private EffectsOverTimeGranularity effectsGranularity;
   private Sequencer sequencer;
   private XaPlayer xaPlayer;
+  private FileData pendingXa;
   private final List<AudioSource> sources = new ArrayList<>();
 
   private boolean running;
@@ -134,6 +135,11 @@ public final class AudioThread implements Runnable {
           source.setActive(true);
         }
       }
+
+      if(this.pendingXa != null && this.xaPlayer.isInitialized()) {
+        this.xaPlayer.loadXa(this.pendingXa);
+        this.pendingXa = null;
+      }
     }
   }
 
@@ -180,6 +186,8 @@ public final class AudioThread implements Runnable {
     this.scheduler.shutdown();
 
     synchronized(this) {
+      this.pendingXa = null;
+
       if(!this.running && this.audioDevice != 0) {
         this.destroyInternal();
         this.xaPlayer.unloadOpusFile();
@@ -341,6 +349,7 @@ public final class AudioThread implements Runnable {
 
     synchronized(this) {
       this.destroyInternal();
+      this.pendingXa = null;
       this.xaPlayer.unloadOpusFile();
     }
   }
@@ -350,6 +359,7 @@ public final class AudioThread implements Runnable {
     this.running = false;
 
     synchronized(this) {
+      this.pendingXa = null;
       this.notify();
     }
   }
@@ -466,16 +476,19 @@ public final class AudioThread implements Runnable {
     synchronized(this) {
       if(this.xaPlayer.isInitialized()) {
         this.xaPlayer.loadXa(fileData);
+      } else {
+        this.xaPlayer.stop();
+        this.xaPlayer.unloadOpusFile();
+        this.pendingXa = new FileData(fileData.getBytes());
       }
     }
   }
 
   public void stopXa() {
     synchronized(this) {
-      if(this.xaPlayer.isInitialized()) {
-        this.xaPlayer.stop();
-        this.xaPlayer.unloadOpusFile();
-      }
+      this.pendingXa = null;
+      this.xaPlayer.stop();
+      this.xaPlayer.unloadOpusFile();
     }
   }
 

--- a/src/main/java/legend/core/audio/AudioThread.java
+++ b/src/main/java/legend/core/audio/AudioThread.java
@@ -182,10 +182,13 @@ public final class AudioThread implements Runnable {
     synchronized(this) {
       if(!this.running && this.audioDevice != 0) {
         this.destroyInternal();
+        this.xaPlayer.unloadOpusFile();
         return;
       }
 
       this.running = false;
+      this.xaPlayer.unloadOpusFile();
+      this.notify();
     }
 
     while(this.audioDevice != 0) {
@@ -338,6 +341,7 @@ public final class AudioThread implements Runnable {
 
     synchronized(this) {
       this.destroyInternal();
+      this.xaPlayer.unloadOpusFile();
     }
   }
 

--- a/src/main/java/legend/core/audio/AudioThread.java
+++ b/src/main/java/legend/core/audio/AudioThread.java
@@ -127,12 +127,14 @@ public final class AudioThread implements Runnable {
       for(int i = 0; i < this.sources.size(); i++) {
         final AudioSource source = this.sources.get(i);
 
-        if(this.audioDevice != 0) {
-          source.init();
-        }
+        synchronized(source) {
+          if(this.audioDevice != 0) {
+            source.init();
+          }
 
-        if(active[i]) {
-          source.setActive(true);
+          if(active[i]) {
+            source.setActive(true);
+          }
         }
       }
 
@@ -206,8 +208,10 @@ public final class AudioThread implements Runnable {
 
   private void destroyInternal() {
     for(final AudioSource source : this.sources) {
-      if(source.isInitialized()) {
-        source.destroy();
+      synchronized(source) {
+        if(source.isInitialized()) {
+          source.destroy();
+        }
       }
     }
 
@@ -252,8 +256,10 @@ public final class AudioThread implements Runnable {
     synchronized(this) {
       this.sources.add(source);
 
-      if(this.audioDevice != 0) {
-        source.init();
+      synchronized(source) {
+        if(this.audioDevice != 0) {
+          source.init();
+        }
       }
 
       return source;
@@ -262,8 +268,10 @@ public final class AudioThread implements Runnable {
 
   public void removeSource(final AudioSource source) {
     synchronized(this) {
-      if(source.isInitialized()) {
-        source.destroy();
+      synchronized(source) {
+        if(source.isInitialized()) {
+          source.destroy();
+        }
       }
 
       this.sources.remove(source);

--- a/src/main/java/legend/core/audio/AudioThread.java
+++ b/src/main/java/legend/core/audio/AudioThread.java
@@ -95,11 +95,18 @@ public final class AudioThread implements Runnable {
       alcGetString(0, ALC_ALL_DEVICES_SPECIFIER); // refresh the list
 
       final String currentDefault = alcGetString(0, ALC_DEFAULT_ALL_DEVICES_SPECIFIER);
+      final boolean defaultDeviceChanged = currentDefault != null && !currentDefault.equals(this.defaultDevice);
 
-      if(currentDefault != null && !currentDefault.equals(this.defaultDevice)) {
-        LOGGER.info("Found new default device %s", currentDefault);
-        this.defaultDevice = currentDefault;
-        this.deviceChanged = true;
+      synchronized(this) {
+        if(defaultDeviceChanged) {
+          LOGGER.info("Found new default device %s", currentDefault);
+          this.defaultDevice = currentDefault;
+        }
+
+        if(defaultDeviceChanged || this.paused) {
+          this.deviceChanged = true;
+          this.notify();
+        }
       }
     }, 2, 2, TimeUnit.SECONDS);
   }
@@ -116,14 +123,15 @@ public final class AudioThread implements Runnable {
       this.destroyInternal();
       this.initInternal();
 
-      if(this.audioDevice != 0) {
-        for(int i = 0; i < this.sources.size(); i++) {
-          final AudioSource source = this.sources.get(i);
-          source.init();
+      for(int i = 0; i < this.sources.size(); i++) {
+        final AudioSource source = this.sources.get(i);
 
-          if(active[i]) {
-            source.setActive(true);
-          }
+        if(this.audioDevice != 0) {
+          source.init();
+        }
+
+        if(active[i]) {
+          source.setActive(true);
         }
       }
     }
@@ -141,6 +149,7 @@ public final class AudioThread implements Runnable {
       if(this.audioContext == 0) {
         LOGGER.error("Failed to create audio context: %#x", alcGetError(this.audioDevice));
         this.destroyInternal();
+        this.paused = true;
         return;
       }
 
@@ -162,7 +171,8 @@ public final class AudioThread implements Runnable {
       this.audioContext = 0;
     }
 
-    LOGGER.warn("Device does not support OpenAL10. Disabling audio.");
+    LOGGER.warn("Device does not support OpenAL10. Retrying audio initialization.");
+    this.destroyInternal();
     this.paused = true;
   }
 
@@ -259,7 +269,7 @@ public final class AudioThread implements Runnable {
       boolean canBuffer = false;
 
       synchronized(this) {
-        while(this.paused) {
+        while(this.paused && !this.deviceChanged) {
           try {
             this.wait();
           } catch(final InterruptedException ignored) { }
@@ -270,14 +280,23 @@ public final class AudioThread implements Runnable {
         }
 
         if(this.deviceChanged) {
-          final String configuredDevice = CONFIG.getConfig(CoreMod.AUDIO_DEVICE_CONFIG.get());
+          this.deviceChanged = false;
 
-          if(configuredDevice.isEmpty() || "<default>".equals(configuredDevice)) {
-            LOGGER.info("Default audio device changed");
+          if(this.paused) {
+            LOGGER.info("Retrying audio initialization");
             this.reinit();
+          } else {
+            final String configuredDevice = CONFIG.getConfig(CoreMod.AUDIO_DEVICE_CONFIG.get());
+
+            if(configuredDevice.isEmpty() || "<default>".equals(configuredDevice)) {
+              LOGGER.info("Default audio device changed");
+              this.reinit();
+            }
           }
 
-          this.deviceChanged = false;
+          if(this.paused) {
+            continue;
+          }
         }
 
         if(this.alcCapabilities.ALC_EXT_disconnect) {
@@ -287,6 +306,10 @@ public final class AudioThread implements Runnable {
           if(connected == 0) {
             LOGGER.warn("Audio device lost");
             this.reinit();
+
+            if(this.paused) {
+              continue;
+            }
           }
         }
 

--- a/src/main/java/legend/core/audio/opus/XaPlayer.java
+++ b/src/main/java/legend/core/audio/opus/XaPlayer.java
@@ -51,7 +51,7 @@ public final class XaPlayer extends AudioSource {
     this.playerVolume = volume;
   }
 
-  public void loadXa(final FileData fileData) {
+  public synchronized void loadXa(final FileData fileData) {
     this.opusFileData = BufferUtils.createByteBuffer(fileData.size());
     this.opusFileData.put(fileData.getBytes());
     this.opusFileData.rewind();
@@ -96,7 +96,12 @@ public final class XaPlayer extends AudioSource {
   }
 
   @Override
-  public void tick() {
+  public synchronized void tick() {
+    if(this.opusFile == NULL) {
+      this.setActive(false);
+      return;
+    }
+
     this.readFile();
     this.bufferOutput(this.format, this.pcm, 48_000);
     super.tick();
@@ -122,7 +127,7 @@ public final class XaPlayer extends AudioSource {
     }
   }
 
-  public void unloadOpusFile() {
+  public synchronized void unloadOpusFile() {
     if(this.opusFile != NULL) {
       OpusFile.op_free(this.opusFile);
       this.opusFile = NULL;
@@ -131,7 +136,7 @@ public final class XaPlayer extends AudioSource {
   }
 
   @Override
-  protected void destroy() {
+  protected synchronized void destroy() {
     if(this.opusFileData != null) {
       this.unloadOpusFile();
     }

--- a/src/main/java/legend/core/audio/opus/XaPlayer.java
+++ b/src/main/java/legend/core/audio/opus/XaPlayer.java
@@ -146,10 +146,6 @@ public final class XaPlayer extends AudioSource {
   @Override
   protected void destroy() {
     synchronized(this.playbackLock) {
-      if(this.opusFileData != null) {
-        this.unloadOpusFile();
-      }
-
       super.destroy();
     }
   }

--- a/src/main/java/legend/core/audio/opus/XaPlayer.java
+++ b/src/main/java/legend/core/audio/opus/XaPlayer.java
@@ -22,6 +22,8 @@ import static org.lwjgl.system.MemoryUtil.NULL;
 public final class XaPlayer extends AudioSource {
   private static final Logger LOGGER = LogManager.getFormatterLogger(XaPlayer.class);
 
+  private final Object playbackLock = new Object();
+
   private ByteBuffer opusFileData;
   private long opusFile;
   private int channelCount;
@@ -51,60 +53,64 @@ public final class XaPlayer extends AudioSource {
     this.playerVolume = volume;
   }
 
-  public synchronized void loadXa(final FileData fileData) {
-    this.opusFileData = BufferUtils.createByteBuffer(fileData.size());
-    this.opusFileData.put(fileData.getBytes());
-    this.opusFileData.rewind();
-    this.samplesRead = 0;
+  public void loadXa(final FileData fileData) {
+    synchronized(this.playbackLock) {
+      this.opusFileData = BufferUtils.createByteBuffer(fileData.size());
+      this.opusFileData.put(fileData.getBytes());
+      this.opusFileData.rewind();
+      this.samplesRead = 0;
 
-    try(final MemoryStack stack = stackPush()) {
-      final IntBuffer error = stack.mallocInt(1);
-      this.opusFile = OpusFile.op_open_memory(this.opusFileData, error);
+      try(final MemoryStack stack = stackPush()) {
+        final IntBuffer error = stack.mallocInt(1);
+        this.opusFile = OpusFile.op_open_memory(this.opusFileData, error);
 
-      if(error.get(0) != 0) {
-        LOGGER.error("Error opening Opus XA file: 0x%x", error.get(0));
+        if(error.get(0) != 0) {
+          LOGGER.error("Error opening Opus XA file: 0x%x", error.get(0));
+        }
       }
-    }
 
-    final int newChannelCount = OpusFile.op_channel_count(this.opusFile, -1);
+      final int newChannelCount = OpusFile.op_channel_count(this.opusFile, -1);
 
-    if(this.channelCount != newChannelCount) {
-      this.channelCount = newChannelCount;
-      this.format = this.channelCount == 2 ? AL_FORMAT_STEREO16 : AL_FORMAT_MONO16;
-      this.pcm = new short[this.samplesPerTick * this.channelCount];
-      this.pcmBuffer = BufferUtils.createShortBuffer(this.pcm.length);
-    }
-
-    this.sampleCount = OpusFile.op_pcm_total(this.opusFile, -1) * newChannelCount;
-
-    if(this.sampleCount < this.samplesPerTick * 4) {
-      throw new RuntimeException("XA file is less than 4 buffers in length (40ms)");
-    }
-
-    this.setActive(true);
-
-    if(this.canBuffer()) {
-      for(int i = 0; i < 4; i++) {
-        this.readFile();
-        this.bufferOutput(this.format, this.pcm, 48_000);
+      if(this.channelCount != newChannelCount) {
+        this.channelCount = newChannelCount;
+        this.format = this.channelCount == 2 ? AL_FORMAT_STEREO16 : AL_FORMAT_MONO16;
+        this.pcm = new short[this.samplesPerTick * this.channelCount];
+        this.pcmBuffer = BufferUtils.createShortBuffer(this.pcm.length);
       }
-    }
 
-    if(this.isActive()) {
-      this.play();
+      this.sampleCount = OpusFile.op_pcm_total(this.opusFile, -1) * newChannelCount;
+
+      if(this.sampleCount < this.samplesPerTick * 4) {
+        throw new RuntimeException("XA file is less than 4 buffers in length (40ms)");
+      }
+
+      this.setActive(true);
+
+      if(this.canBuffer()) {
+        for(int i = 0; i < 4; i++) {
+          this.readFile();
+          this.bufferOutput(this.format, this.pcm, 48_000);
+        }
+      }
+
+      if(this.isActive()) {
+        this.play();
+      }
     }
   }
 
   @Override
-  public synchronized void tick() {
-    if(this.opusFile == NULL) {
-      this.setActive(false);
-      return;
-    }
+  public void tick() {
+    synchronized(this.playbackLock) {
+      if(this.opusFile == NULL) {
+        this.setActive(false);
+        return;
+      }
 
-    this.readFile();
-    this.bufferOutput(this.format, this.pcm, 48_000);
-    super.tick();
+      this.readFile();
+      this.bufferOutput(this.format, this.pcm, 48_000);
+      super.tick();
+    }
   }
 
   private void readFile() {
@@ -127,20 +133,24 @@ public final class XaPlayer extends AudioSource {
     }
   }
 
-  public synchronized void unloadOpusFile() {
-    if(this.opusFile != NULL) {
-      OpusFile.op_free(this.opusFile);
-      this.opusFile = NULL;
-      this.opusFileData = null;
+  public void unloadOpusFile() {
+    synchronized(this.playbackLock) {
+      if(this.opusFile != NULL) {
+        OpusFile.op_free(this.opusFile);
+        this.opusFile = NULL;
+        this.opusFileData = null;
+      }
     }
   }
 
   @Override
-  protected synchronized void destroy() {
-    if(this.opusFileData != null) {
-      this.unloadOpusFile();
-    }
+  protected void destroy() {
+    synchronized(this.playbackLock) {
+      if(this.opusFileData != null) {
+        this.unloadOpusFile();
+      }
 
-    super.destroy();
+      super.destroy();
+    }
   }
 }


### PR DESCRIPTION
Fixes #2394

### Motivation
- Switching from bluetooth to speakers would crash, was relatively annoying in this void voyage through time

### Desc
- Stops doing file things when files are freed

### Reproducibility
- Couldn't reproduce as described
- Reproduced by turning off bluetooth while d spell audio was going on
  - no longer crashes

### QA
- Game didn't crash at 10x speed with Atomic Mind -> Divine DG Ball in Special
  - This I thought would break but keeping everything tight in java land seems to prevent naughty leakage to native code