### PR TITLE
Fix end-of-disc save transition flashing previous submap (#659)

### DIFF
--- a/src/main/java/legend/game/Menus.java
+++ b/src/main/java/legend/game/Menus.java
@@ -102,7 +102,9 @@ public final class Menus {
         whichMenu_800bdc38 = WhichMenu.NONE_0;
 
         deallocateRenderables(0xff);
-        if(!unloadSaveGameMenu) startFadeEffect(2, 10);
+        if(!unloadSaveGameMenu) {
+          startFadeEffect(2, 10);
+        }
         currentEngineState_8004dd04.menuClosed();
 
         textZ_800bdf00 = 13;

--- a/src/main/java/legend/game/Menus.java
+++ b/src/main/java/legend/game/Menus.java
@@ -91,6 +91,7 @@ public final class Menus {
       case RENDER_NEW_MENU, RENDER_SAVE_GAME_MENU_19 -> menuStack.render();
 
       case UNLOAD, UNLOAD_SAVE_GAME_MENU_20, UNLOAD_POST_COMBAT_REPORT_30 -> {
+        final boolean unloadSaveGameMenu = whichMenu_800bdc38 == WhichMenu.UNLOAD_SAVE_GAME_MENU_20;
         menuStack.reset();
 
         if(whichMenu_800bdc38 != WhichMenu.UNLOAD_SAVE_GAME_MENU_20 && whichMenu_800bdc38 != WhichMenu.UNLOAD_POST_COMBAT_REPORT_30) {
@@ -101,7 +102,7 @@ public final class Menus {
         whichMenu_800bdc38 = WhichMenu.NONE_0;
 
         deallocateRenderables(0xff);
-        startFadeEffect(2, 10);
+        if(!unloadSaveGameMenu) startFadeEffect(2, 10);
         currentEngineState_8004dd04.menuClosed();
 
         textZ_800bdf00 = 13;

--- a/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
+++ b/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
@@ -141,7 +141,9 @@ public class SaveGameScreen extends MenuScreen {
   }
 
   private void onSelection(@Nullable final SavedGame save) {
-    if(this.closing) return;
+    if(this.closing) {
+      return;
+    }
 
     playMenuSound(2);
 

--- a/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
+++ b/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static legend.core.GameEngine.SAVES;
 import static legend.game.EngineStates.currentEngineState_8004dd04;
+import static legend.game.FullScreenEffects.fullScreenEffect_800bb140;
 import static legend.game.FullScreenEffects.startFadeEffect;
 import static legend.game.Menus.deallocateRenderables;
 import static legend.game.SItem.UI_TEXT_CENTERED;
@@ -40,9 +41,16 @@ public class SaveGameScreen extends MenuScreen {
   private final List<CompletableFuture<SavedGame>> saves;
 
   private final Runnable unload;
+  private final boolean fadeOutOnClose;
+  private boolean closing;
 
   public SaveGameScreen(final Runnable unload) {
+    this(unload, false);
+  }
+
+  public SaveGameScreen(final Runnable unload, final boolean fadeOutOnClose) {
     this.unload = unload;
+    this.fadeOutOnClose = fadeOutOnClose;
 
     deallocateRenderables(0xff);
     startFadeEffect(2, 10);
@@ -125,9 +133,16 @@ public class SaveGameScreen extends MenuScreen {
   @Override
   protected void render() {
     renderText(I18n.translate("lod_core.ui.save_game.save_game"), 188, 10, UI_TEXT_CENTERED);
+
+    if(this.closing && fullScreenEffect_800bb140.currentColour_28 >= 0xff) {
+      this.closing = false;
+      this.unload.run();
+    }
   }
 
   private void onSelection(@Nullable final SavedGame save) {
+    if(this.closing) return;
+
     playMenuSound(2);
 
     if(save == null) {
@@ -146,7 +161,7 @@ public class SaveGameScreen extends MenuScreen {
 
       try {
         SAVES.newSave(name, campaignType.get(), currentEngineState_8004dd04, gameState_800babc8);
-        this.unload.run();
+        this.close();
       } catch(final SaveFailedException e) {
         menuStack.pushScreen(new MessageBoxScreen(I18n.translate("lod_core.ui.save_game.save_failed"), MessageBoxType.ALERT, r -> { }));
         LOGGER.error("Failed to save game", e);
@@ -158,7 +173,7 @@ public class SaveGameScreen extends MenuScreen {
     if(result == MessageBoxResult.YES) {
       try {
         SAVES.overwriteSave(save.fileName, save.saveName, campaignType.get(), currentEngineState_8004dd04, gameState_800babc8);
-        this.unload.run();
+        this.close();
       } catch(final SaveFailedException e) {
         menuStack.pushScreen(new MessageBoxScreen(I18n.translate("lod_core.ui.save_game.save_failed"), MessageBoxType.ALERT, r -> { }));
         LOGGER.error("Failed to save game", e);
@@ -167,6 +182,8 @@ public class SaveGameScreen extends MenuScreen {
   }
 
   private void menuDelete() {
+    if(this.closing) return;
+
     playMenuSound(40);
 
     if(this.saveList.size() == 1) {
@@ -192,7 +209,18 @@ public class SaveGameScreen extends MenuScreen {
   }
 
   private void menuEscape() {
+    if(this.closing) return;
+
     playMenuSound(3);
-    this.unload.run();
+    this.close();
+  }
+
+  private void close() {
+    if(this.fadeOutOnClose) {
+      startFadeEffect(1, 10);
+      this.closing = true;
+    } else {
+      this.unload.run();
+    }
   }
 }

--- a/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
+++ b/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
@@ -184,7 +184,9 @@ public class SaveGameScreen extends MenuScreen {
   }
 
   private void menuDelete() {
-    if(this.closing) return;
+    if(this.closing) {
+      return;
+    }
 
     playMenuSound(40);
 

--- a/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
+++ b/src/main/java/legend/game/inventory/screens/SaveGameScreen.java
@@ -213,7 +213,9 @@ public class SaveGameScreen extends MenuScreen {
   }
 
   private void menuEscape() {
-    if(this.closing) return;
+    if(this.closing) {
+      return;
+    }
 
     playMenuSound(3);
     this.close();

--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -3950,7 +3950,7 @@ public class SMap extends EngineState<SMap> {
       collidedPrimitiveIndex_80052c38 = this.submapChapterDestinations_800f7e2c[gameState_800babc8.chapterIndex_98].submapScene_04;
       submapCut_80052c30 = this.submapChapterDestinations_800f7e2c[gameState_800babc8.chapterIndex_98].submapCut_00;
       this.mapTransitionData_800cab24.clear();
-      this.menuTransition = () -> initMenu(WhichMenu.RENDER_SAVE_GAME_MENU_19, () -> new SaveGameScreen(() -> whichMenu_800bdc38 = WhichMenu.UNLOAD_SAVE_GAME_MENU_20));
+      this.menuTransition = () -> initMenu(WhichMenu.RENDER_SAVE_GAME_MENU_19, () -> new SaveGameScreen(() -> whichMenu_800bdc38 = WhichMenu.UNLOAD_SAVE_GAME_MENU_20, true));
       this.smapLoadingStage_800cb430 = SubmapState.LOAD_MENU_13;
       return;
     }


### PR DESCRIPTION
Fixes #659 

### Desc
- Special edge case handling for end of chapter menu + submap + save transitions
  - Saw no other means to fixing this than to provide the right code in the right place for the current implementation
  - Other than to rewrite menus (again)
  - tldr -> added a gap in capabilities to menus
- I believe the  `UNLOAD_SAVE_GAME_MENU_20` is well-behaved and contained that building a state lifecycle around it isn't going to bleed out to the other states
  - Don't hate me otherwise


### QA

- Before
  - https://streamable.com/h940x6
- After
  - https://streamable.com/3nsals