### PR TITLE
Add lifecycle sources to character level-up events

### DIFF
--- a/src/main/java/legend/game/characters/CharacterData2c.java
+++ b/src/main/java/legend/game/characters/CharacterData2c.java
@@ -225,6 +225,10 @@ public class CharacterData2c {
     this.template.applyLevelUp(this, actions);
   }
 
+  public void applyLevelUp(@Nullable final LevelUpActions actions, final LevelUpSource source) {
+    this.template.applyLevelUp(this, actions, source);
+  }
+
   public void applyDragoonLevelUp(@Nullable final LevelUpActions actions) {
     this.template.applyDragoonLevelUp(this, actions);
   }

--- a/src/main/java/legend/game/characters/CharacterTemplate.java
+++ b/src/main/java/legend/game/characters/CharacterTemplate.java
@@ -32,6 +32,11 @@ public abstract class CharacterTemplate extends RegistryEntry {
   public abstract void renderTransformIcon(final CharacterData2c character, final PlayerBattleEntity bent, final MV transforms, final int frame);
 
   public abstract void applyLevelUp(final CharacterData2c character, @Nullable final LevelUpActions actions);
+
+  public void applyLevelUp(final CharacterData2c character, @Nullable final LevelUpActions actions, final LevelUpSource source) {
+    this.applyLevelUp(character, actions);
+  }
+
   public abstract void applyDragoonLevelUp(final CharacterData2c character, @Nullable final LevelUpActions actions);
   public abstract void checkUnlocks(final CharacterData2c character, final LevelUpActions actions);
   public abstract int getXpToNextLevel(final CharacterData2c character);

--- a/src/main/java/legend/game/characters/LevelUpSource.java
+++ b/src/main/java/legend/game/characters/LevelUpSource.java
@@ -1,0 +1,7 @@
+package legend.game.characters;
+
+public enum LevelUpSource {
+  INITIALIZATION,
+  GAMEPLAY,
+  DEBUGGER,
+}

--- a/src/main/java/legend/game/debugger/CharacterEditorController.java
+++ b/src/main/java/legend/game/debugger/CharacterEditorController.java
@@ -10,6 +10,7 @@ import javafx.stage.Stage;
 import legend.game.additions.UnlockState;
 import legend.game.characters.CharacterAdditionInfo;
 import legend.game.characters.CharacterData2c;
+import legend.game.characters.LevelUpSource;
 import legend.game.characters.VitalsStat;
 import legend.game.i18n.I18n;
 import legend.game.inventory.Equipment;
@@ -331,7 +332,7 @@ public class CharacterEditorController {
   }
 
   public void onLevelUpClick() {
-    this.charData.applyLevelUp(null);
+    this.charData.applyLevelUp(null, LevelUpSource.DEBUGGER);
     this.refresh();
   }
 

--- a/src/main/java/legend/game/inventory/screens/PostBattleScreen.java
+++ b/src/main/java/legend/game/inventory/screens/PostBattleScreen.java
@@ -15,6 +15,7 @@ import legend.game.additions.Addition;
 import legend.game.characters.CharacterAdditionInfo;
 import legend.game.characters.CharacterData2c;
 import legend.game.characters.LevelUpActions;
+import legend.game.characters.LevelUpSource;
 import legend.game.combat.types.EnemyDrop;
 import legend.game.i18n.I18n;
 import legend.game.inventory.SpellStats0c;
@@ -541,7 +542,7 @@ public class PostBattleScreen extends MenuScreen {
       //LAB_8010cd30
       final LevelUpActions levelUpActions = new LevelUpActions();
       while(character.xp_00 >= character.getXpToNextLevel() && character.level_12 < CONFIG.getConfig(MAX_LEVEL.get())) {
-        character.applyLevelUp(levelUpActions);
+        character.applyLevelUp(levelUpActions, LevelUpSource.GAMEPLAY);
         this.levelsGained_8011e1c8.mergeInt(character, 1, Integer::sum);
       }
 

--- a/src/main/java/legend/game/modding/events/characters/PostCharacterLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PostCharacterLevelUpEvent.java
@@ -4,6 +4,16 @@ import legend.game.characters.CharacterData2c;
 import legend.game.characters.LevelUpSource;
 import org.legendofdragoon.modloader.events.Event;
 
+/**
+ * Fired after a character level-up is applied.
+ *
+ * <p>The {@link LevelUpSource} stored in {@link #source} is one of:</p>
+ * <ul>
+ *   <li>{@link LevelUpSource#INITIALIZATION} when building initial or restored character state</li>
+ *   <li>{@link LevelUpSource#GAMEPLAY} when progression is earned during gameplay</li>
+ *   <li>{@link LevelUpSource#DEBUGGER} when applied through the character debugger</li>
+ * </ul>
+ */
 public class PostCharacterLevelUpEvent extends Event {
   public final CharacterData2c character;
   public final LevelUpSource source;

--- a/src/main/java/legend/game/modding/events/characters/PostCharacterLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PostCharacterLevelUpEvent.java
@@ -1,12 +1,19 @@
 package legend.game.modding.events.characters;
 
 import legend.game.characters.CharacterData2c;
+import legend.game.characters.LevelUpSource;
 import org.legendofdragoon.modloader.events.Event;
 
 public class PostCharacterLevelUpEvent extends Event {
   public final CharacterData2c character;
+  public final LevelUpSource source;
 
   public PostCharacterLevelUpEvent(final CharacterData2c character) {
+    this(character, LevelUpSource.GAMEPLAY);
+  }
+
+  public PostCharacterLevelUpEvent(final CharacterData2c character, final LevelUpSource source) {
     this.character = character;
+    this.source = source;
   }
 }

--- a/src/main/java/legend/game/modding/events/characters/PreCharacterLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PreCharacterLevelUpEvent.java
@@ -7,6 +7,16 @@ import legend.game.characters.LevelUpSource;
 import legend.game.characters.StatType;
 import org.legendofdragoon.modloader.events.CancelableEvent;
 
+/**
+ * Fired before a character level-up is applied.
+ *
+ * <p>The {@link LevelUpSource} stored in {@link #source} is one of:</p>
+ * <ul>
+ *   <li>{@link LevelUpSource#INITIALIZATION} when building initial or restored character state</li>
+ *   <li>{@link LevelUpSource#GAMEPLAY} when progression is earned during gameplay</li>
+ *   <li>{@link LevelUpSource#DEBUGGER} when applied through the character debugger</li>
+ * </ul>
+ */
 public class PreCharacterLevelUpEvent extends CancelableEvent {
   public final CharacterData2c character;
   public final LevelUpSource source;

--- a/src/main/java/legend/game/modding/events/characters/PreCharacterLevelUpEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/PreCharacterLevelUpEvent.java
@@ -3,16 +3,23 @@ package legend.game.modding.events.characters;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import legend.game.characters.CharacterData2c;
+import legend.game.characters.LevelUpSource;
 import legend.game.characters.StatType;
 import org.legendofdragoon.modloader.events.CancelableEvent;
 
 public class PreCharacterLevelUpEvent extends CancelableEvent {
   public final CharacterData2c character;
+  public final LevelUpSource source;
 
   public final Object2IntMap<StatType<?>> statsToAdd = new Object2IntOpenHashMap<>();
   public int levelsToAdd = 1;
 
   public PreCharacterLevelUpEvent(final CharacterData2c character) {
+    this(character, LevelUpSource.GAMEPLAY);
+  }
+
+  public PreCharacterLevelUpEvent(final CharacterData2c character, final LevelUpSource source) {
     this.character = character;
+    this.source = source;
   }
 }

--- a/src/main/java/legend/game/saves/RetailSavedGame.java
+++ b/src/main/java/legend/game/saves/RetailSavedGame.java
@@ -8,6 +8,7 @@ import legend.game.characters.CharacterAdditionInfo;
 import legend.game.characters.CharacterData2c;
 import legend.game.characters.CharacterSpellInfo;
 import legend.game.characters.CharacterTemplate;
+import legend.game.characters.LevelUpSource;
 import legend.game.inventory.Equipment;
 import legend.game.inventory.Item;
 import legend.game.inventory.ItemStack;
@@ -138,7 +139,7 @@ public class RetailSavedGame extends SavedGame {
       gameState.charData_32c.add(character);
 
       while(character.level_12 < savedCharacter.level) {
-        character.applyLevelUp(null);
+        character.applyLevelUp(null, LevelUpSource.INITIALIZATION);
       }
 
       while(character.dlevel_13 < savedCharacter.dlevel) {

--- a/src/main/java/legend/game/saves/SeveredSavedCharacterV1.java
+++ b/src/main/java/legend/game/saves/SeveredSavedCharacterV1.java
@@ -6,6 +6,7 @@ import legend.game.characters.CharacterAdditionInfo;
 import legend.game.characters.CharacterData2c;
 import legend.game.characters.CharacterSpellInfo;
 import legend.game.characters.CharacterTemplate;
+import legend.game.characters.LevelUpSource;
 import legend.game.characters.VitalsStat;
 import legend.game.inventory.Equipment;
 import legend.game.inventory.SpellStats0c;
@@ -78,7 +79,7 @@ public class SeveredSavedCharacterV1 implements SavedCharacter {
     character.hasTransformed = this.hasTransformed;
 
     for(int i = 1; i < this.level; i++) {
-      template.applyLevelUp(character, null);
+      template.applyLevelUp(character, null, LevelUpSource.INITIALIZATION);
     }
 
     for(int i = 1; i < this.dlevel; i++) {

--- a/src/main/java/legend/lodmod/RetailCampaignType.java
+++ b/src/main/java/legend/lodmod/RetailCampaignType.java
@@ -3,6 +3,7 @@ package legend.lodmod;
 import legend.game.fmv.Fmv;
 import legend.game.saves.CampaignType;
 import legend.game.characters.CharacterData2c;
+import legend.game.characters.LevelUpSource;
 import legend.game.types.EquipmentSlot;
 import legend.game.types.GameState52c;
 
@@ -101,11 +102,11 @@ public class RetailCampaignType extends CampaignType {
 
   private void levelUp(final CharacterData2c character, final int level) {
     while(character.level_12 < level - 1) {
-      character.applyLevelUp(null);
+      character.applyLevelUp(null, LevelUpSource.INITIALIZATION);
     }
 
     character.xp_00 = character.getXpToNextLevel();
-    character.applyLevelUp(null);
+    character.applyLevelUp(null, LevelUpSource.INITIALIZATION);
 
     character.stats.getStat(HP_STAT.get()).restore();
     character.stats.getStat(MP_STAT.get()).restore();

--- a/src/main/java/legend/lodmod/characters/AlbertTemplate.java
+++ b/src/main/java/legend/lodmod/characters/AlbertTemplate.java
@@ -7,6 +7,7 @@ import legend.game.characters.AdditionMasteryUnlockCriterion;
 import legend.game.characters.CharacterAdditionInfo;
 import legend.game.characters.CharacterData2c;
 import legend.game.characters.CharacterSpellInfo;
+import legend.game.characters.LevelUpSource;
 import legend.game.characters.SpellDragoonLevelUnlockCriterion;
 import legend.game.characters.SpellDragoonSpiritUnlockCriterion;
 import legend.game.characters.StatCollection;
@@ -52,7 +53,7 @@ public class AlbertTemplate extends LavitzTemplate {
     stats.getStat(MAGIC_HIT_STAT.get()).setRaw(100);
     stats.getStat(GUARD_HEAL_STAT.get()).setRaw(10);
 
-    this.applyLevelUp(character, null);
+    this.applyLevelUp(character, null, LevelUpSource.INITIALIZATION);
     this.applyDragoonLevelUp(character, null);
 
     final VitalsStat hp = character.stats.getStat(HP_STAT.get());

--- a/src/main/java/legend/lodmod/characters/MirandaTemplate.java
+++ b/src/main/java/legend/lodmod/characters/MirandaTemplate.java
@@ -2,6 +2,7 @@ package legend.lodmod.characters;
 
 import legend.game.characters.CharacterData2c;
 import legend.game.characters.CharacterSpellInfo;
+import legend.game.characters.LevelUpSource;
 import legend.game.characters.SpellDragoonLevelUnlockCriterion;
 import legend.game.characters.SpellDragoonSpiritUnlockCriterion;
 import legend.game.characters.StatCollection;
@@ -46,7 +47,7 @@ public class MirandaTemplate extends ShanaTemplate {
     stats.getStat(MAGIC_HIT_STAT.get()).setRaw(100);
     stats.getStat(GUARD_HEAL_STAT.get()).setRaw(10);
 
-    this.applyLevelUp(character, null);
+    this.applyLevelUp(character, null, LevelUpSource.INITIALIZATION);
     this.applyDragoonLevelUp(character, null);
 
     final VitalsStat hp = character.stats.getStat(HP_STAT.get());

--- a/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
+++ b/src/main/java/legend/lodmod/characters/RetailCharacterTemplate.java
@@ -9,6 +9,7 @@ import legend.game.characters.CharacterData2c;
 import legend.game.characters.CharacterSpellInfo;
 import legend.game.characters.CharacterTemplate;
 import legend.game.characters.LevelUpActions;
+import legend.game.characters.LevelUpSource;
 import legend.game.characters.StatCollection;
 import legend.game.characters.VitalsStat;
 import legend.game.combat.bent.PlayerBattleEntity;
@@ -71,7 +72,7 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
     stats.getStat(MAGIC_HIT_STAT.get()).setRaw(100);
     stats.getStat(GUARD_HEAL_STAT.get()).setRaw(10);
 
-    this.applyLevelUp(character, null);
+    this.applyLevelUp(character, null, LevelUpSource.INITIALIZATION);
     this.applyDragoonLevelUp(character, null);
 
     final VitalsStat hp = character.stats.getStat(HP_STAT.get());
@@ -188,7 +189,12 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
 
   @Override
   public void applyLevelUp(final CharacterData2c character, @Nullable final LevelUpActions actions) {
-    final PreCharacterLevelUpEvent event = new PreCharacterLevelUpEvent(character);
+    this.applyLevelUp(character, actions, LevelUpSource.GAMEPLAY);
+  }
+
+  @Override
+  public void applyLevelUp(final CharacterData2c character, @Nullable final LevelUpActions actions, final LevelUpSource source) {
+    final PreCharacterLevelUpEvent event = new PreCharacterLevelUpEvent(character, source);
 
     event.statsToAdd.put(HP_STAT.get(), this.getHpToAdd(character.level_12));
     event.statsToAdd.put(ATTACK_STAT.get(), this.getAttackToAdd(character.level_12));
@@ -206,7 +212,7 @@ public abstract class RetailCharacterTemplate extends CharacterTemplate {
     character.level_12 += event.levelsToAdd;
 
     this.checkUnlocks(character, actions);
-    EVENTS.postEvent(new PostCharacterLevelUpEvent(character));
+    EVENTS.postEvent(new PostCharacterLevelUpEvent(character, source));
   }
 
   @Override


### PR DESCRIPTION
fixes #2760 

### Motivation
- `PostCharacterLevelUpEvent` fires during character initialization, save reconstruction, gameplay progression, and debugger changes
- Mods cannot distinguish real progression from setup

**Description**
  - Added `LevelUpSource` with `INITIALIZATION`, `GAMEPLAY`, and `DEBUGGER`
  - Retained existing APIs with `GAMEPLAY` defaults, preserving existing API surface behaviour
  - Lifecycle classifications:
    - `INITIALIZATION`: character construction, new-campaign setup, retail/V1 save reconstruction
    - `GAMEPLAY`: post-battle level gains
    - `DEBUGGER`: character-editor level changes
  - Example mod usage:
    ```java
    if(event.source != LevelUpSource.GAMEPLAY) return;
    ```

These events are so deeply nested in other entity lifecycles that to have different events per lifecycle type seemed more painful than the events sharing a backed contract on sourcing with each other as an event capability. Can't think of any other approach that does not involve some heavy composition refactors with character templates?