### PR TITLE
Prevent timestamp from being set if unlockstate didn't change

### DIFF
--- a/src/main/java/legend/game/characters/CharacterAdditionInfo.java
+++ b/src/main/java/legend/game/characters/CharacterAdditionInfo.java
@@ -26,6 +26,10 @@ public class CharacterAdditionInfo {
   }
 
   public void setUnlockState(final UnlockState unlockState, final int timestamp) {
+    if (this.unlockState == unlockState) {
+      return;
+    }
+
     this.unlockState = unlockState;
 
     if(unlockState.isUsable()) {

--- a/src/main/java/legend/game/characters/CharacterSpellInfo.java
+++ b/src/main/java/legend/game/characters/CharacterSpellInfo.java
@@ -28,6 +28,10 @@ public class CharacterSpellInfo {
   }
 
   public void setUnlockState(final UnlockState unlockState, final int timestamp) {
+    if (this.unlockState == unlockState) {
+      return;
+    }
+    
     this.unlockState = unlockState;
 
     if(unlockState.isUsable()) {


### PR DESCRIPTION
If the addition's unlockstate has not changed, we do not need to update the timestamp