### PR TITLE
fix AudioThread track OS default for unset audio device configuration

### DIFF
--- a/src/main/java/legend/core/audio/AudioThread.java
+++ b/src/main/java/legend/core/audio/AudioThread.java
@@ -270,7 +270,9 @@ public final class AudioThread implements Runnable {
         }
 
         if(this.deviceChanged) {
-          if("<default>".equals(CONFIG.getConfig(CoreMod.AUDIO_DEVICE_CONFIG.get()))) {
+          final String configuredDevice = CONFIG.getConfig(CoreMod.AUDIO_DEVICE_CONFIG.get());
+
+          if(configuredDevice.isEmpty() || "<default>".equals(configuredDevice)) {
             LOGGER.info("Default audio device changed");
             this.reinit();
           }


### PR DESCRIPTION
### Motivation

Bluetooth headphones and one Speaker, no other audio devices. Turning bluetooth off or turning the bluetooth device off force changes windows default device to the Speaker.

SC I noticed was not auto changing its audio output when the Audio config is set to `Default`.

### Description

- Default is a special option that will now track and always use whatever the Default device is set to on the OS
- Specific device selections will ignore this new behaviour as usual