### PR TITLE
Load registries when entering mod menus on new campaign starts

### DIFF
--- a/src/main/java/legend/core/GameEngine.java
+++ b/src/main/java/legend/core/GameEngine.java
@@ -362,7 +362,7 @@ public final class GameEngine {
   }
 
   public static void bootRegistries() {
-    REGISTRY_ACCESS.initializeRemaining();
+    initializeRemainingRegistries();
     ItemIcon.loadIconMap();
 
     LOGGER.info("Creating texture atlas...");
@@ -382,6 +382,10 @@ public final class GameEngine {
     TEXTURE_ATLAS.setPersistent(true);
 
     LOGGER.info("Texture atlas created in %.02fs", (System.nanoTime() - t) / 1_000_000_000.0f);
+  }
+
+  public static void initializeRemainingRegistries() {
+    REGISTRY_ACCESS.initializeRemaining();
   }
 
   private static void transitionToGame() {

--- a/src/main/java/legend/game/inventory/screens/OptionsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/OptionsScreen.java
@@ -44,6 +44,7 @@ public class OptionsScreen extends VerticalLayoutScreen {
   private final Map<Control, ConfigEntry<?>> helpEntries = new HashMap<>();
 
   public OptionsScreen(final ConfigCollection config, final Set<ConfigStorageLocation> validLocations, final ConfigCategory category, final Runnable unload) {
+    GameEngine.initializeRemainingRegistries();
     deallocateRenderables(0xff);
 
     this.unload = unload;


### PR DESCRIPTION
### Motivation

In Irongoon I let people dictate specific registry entries for some configs. On a new campaign start...I need to know what mods and thus what registries have been selected so I can serve the right options to them in the Irongoon menus.

So I need to load registries from everything that is 'valid' to load from.

They go here in a New Campaign start to do element overrides for Characters (few other places like this exist)
<img width="1174" height="263" alt="image" src="https://github.com/user-attachments/assets/d81db69f-bb77-43c4-8fd8-d88a86fb22fd" />

Without these changes...all I can let them do is to Skip randomizing these characters.
<img width="1272" height="934" alt="image" src="https://github.com/user-attachments/assets/dbdf738e-526c-493a-9f43-ec96f3d6db06" />

What I actually want is to let them select an element that forces the character into that element regardless of whatever Irongoon wants to do. But if Mod Y had CheesePotato element...I need to see that to give them that option here.

<img width="1259" height="869" alt="image" src="https://github.com/user-attachments/assets/5b1e03d4-af5f-4fdb-8831-54507e8e1e9a" />
