### PR TITLE
Apply patch for prison key

### DIFF
--- a/patches/scripts.csv
+++ b/patches/scripts.csv
@@ -126,6 +126,7 @@ diff,SECT/DRGN21.BIN/57/2,scripts/DRGN21/57/2.diff,"Hellena Prison, fix dart fee
 diff,SECT/DRGN21.BIN/60/2,scripts/DRGN21/60/2.diff,"Hellena Prison, fix dart feet noclipping"
 diff,SECT/DRGN21.BIN/60/4,scripts/DRGN21/60/2.diff,"Hellena Prison, fix dart feet noclipping"
 diff,SECT/DRGN21.BIN/60/5,scripts/DRGN21/60/2.diff,"Hellena Prison, fix dart feet noclipping"
+diff,SECT/DRGN21.BIN/66/1,scripts/DRGN21/66/1.diff,"Check hasGood instead of flags for shana tower door, GH#2794"
 diff,SECT/DRGN21.BIN/66/2,scripts/DRGN21/66/2.diff,"Hellena Prison, fix dart feet noclipping"
 diff,SECT/DRGN21.BIN/66/4,scripts/DRGN21/66/4.diff,"Hellena Prison, fix dart feet noclipping"
 diff,SECT/DRGN22.BIN/57/2,scripts/DRGN21/57/2.diff,"Hellena Prison Disc 2, fix dart feet noclipping"

--- a/patches/scripts/DRGN21/66/1.diff
+++ b/patches/scripts/DRGN21/66/1.diff
@@ -1,0 +1,20 @@
+--- original
++++ modified
+@@ -592,7 +592,7 @@
+ call 307, stor[0], 0x28, 0x3c, 0x14
+ call 318, stor[0], 0x14, 0x28, 0x14
+ gosub inl[:LABEL_77]
+-call 5, 0x9, stor[24]
++call 914, id[lod:prison_key], stor[24]
+ jmp_cmp !=, 0x0, stor[24], inl[:LABEL_74]
+ call 779, inl[:LABEL_98]
+ jmp inl[:LABEL_75]
+@@ -707,7 +707,7 @@
+ return
+ LABEL_87:
+ gosub inl[:LABEL_53]
+-call 5, 0x9, stor[24]
++call 914, id[lod:prison_key], stor[24]
+ jmp_cmp !=, 0x0, stor[24], inl[:LABEL_88]
+ mov 0x7, stor[24]
+ mov 0x8, stor[25]


### PR DESCRIPTION
in order to align with behavior elsewhere in LoD, utilize `scriptHasGood` to check if player can open the door to shana's tower in hellena prison

closes #2794 
closes https://github.com/pkolb-dev/Archipelagoon/issues/104