### PR TITLE
Config preset fixes

### DIFF
--- a/src/main/java/legend/core/font/RetailFontConfigEntry.java
+++ b/src/main/java/legend/core/font/RetailFontConfigEntry.java
@@ -3,6 +3,7 @@ package legend.core.font;
 import legend.core.GameEngine;
 import legend.game.inventory.screens.controls.Dropdown;
 import legend.game.saves.ConfigCategory;
+import legend.game.saves.ConfigCollection;
 import legend.game.saves.ConfigStorageLocation;
 import legend.game.saves.StringConfigEntry;
 
@@ -11,7 +12,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static legend.core.GameEngine.CONFIG;
 import static legend.core.GameEngine.FONTS;
 
 public class RetailFontConfigEntry extends StringConfigEntry {
@@ -22,12 +22,9 @@ public class RetailFontConfigEntry extends StringConfigEntry {
       final Path fontsDir = Path.of("gfx", "fonts");
 
       final Dropdown<Font> dropdown = new Dropdown<>((i, font) -> font.name);
-      dropdown.onSelection(index -> {
-        gameState.setConfig(this, fontsDir.relativize(dropdown.getSelectedOption().path).toString());
-        GameEngine.DEFAULT_FONT = dropdown.getSelectedOption();
-      });
+      dropdown.onSelection(index -> gameState.setConfig(this, fontsDir.relativize(dropdown.getSelectedOption().path).toString()));
 
-      final Path currentPath = Path.of(CONFIG.getConfig(this));
+      final Path currentPath = Path.of(current);
 
       try(final DirectoryStream<Path> dir = Files.newDirectoryStream(fontsDir)) {
         for(final Path path : dir) {
@@ -46,5 +43,11 @@ public class RetailFontConfigEntry extends StringConfigEntry {
 
       return dropdown;
     });
+  }
+
+  @Override
+  public void onChange(final ConfigCollection configCollection, final String oldValue, final String newValue) {
+    super.onChange(configCollection, oldValue, newValue);
+    GameEngine.DEFAULT_FONT = FONTS.get(Path.of("gfx", "fonts").resolve(newValue));
   }
 }

--- a/src/main/java/legend/core/platform/input/InputBindings.java
+++ b/src/main/java/legend/core/platform/input/InputBindings.java
@@ -33,7 +33,7 @@ public final class InputBindings {
 
   public static void loadBindings(final ConfigCollection config) {
     final Map<RegistryDelegate<InputAction>, List<InputActivation>> savedBindings = config.getConfig(CoreMod.CONTROLLER_KEYBINDS_CONFIG.get());
-    savedBindings.forEach(InputBindings::overwriteBindings);
+    savedBindings.forEach((action, activations) -> overwriteBindings(REGISTRIES.inputActions.getEntry(action.getId()), activations));
   }
 
   public static void saveBindings(final ConfigCollection config) {

--- a/src/main/java/legend/game/inventory/screens/KeybindsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/KeybindsScreen.java
@@ -19,6 +19,7 @@ import legend.game.types.MessageBoxResult;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -31,12 +32,14 @@ import static legend.game.FullScreenEffects.startFadeEffect;
 import static legend.game.Menus.deallocateRenderables;
 import static legend.game.SItem.menuStack;
 import static legend.game.modding.coremod.CoreMod.INPUT_ACTION_MENU_BACK;
+import static legend.game.modding.coremod.CoreMod.CONTROLLER_KEYBINDS_CONFIG;
 import static legend.game.sound.Audio.playMenuSound;
 
 public class KeybindsScreen extends VerticalLayoutScreen {
   private final Runnable unload;
   private final ConfigCollection config;
   private final ConfigCollection originalBindings;
+  private final byte[] openingBindings;
 
   public KeybindsScreen(final ConfigCollection config, final Runnable unload) {
     deallocateRenderables(0xff);
@@ -53,6 +56,7 @@ public class KeybindsScreen extends VerticalLayoutScreen {
     InputBindings.initBindings();
     InputBindings.loadBindings(config);
 
+    this.openingBindings = snapshotBindings();
     this.addControl(new Background());
 
     final List<InputAction> actions = new ArrayList<>();
@@ -86,6 +90,13 @@ public class KeybindsScreen extends VerticalLayoutScreen {
         this.addRow(new I18nText(action.getTranslationKey()), control);
       }
     }
+  }
+
+  private static byte[] snapshotBindings() {
+    final ConfigCollection bindings = new ConfigCollection(false);
+    InputBindings.saveBindings(bindings);
+    final var entry = CONTROLLER_KEYBINDS_CONFIG.get();
+    return entry.serializer.apply(bindings.getConfig(entry));
   }
 
   private String actionToString(final InputAction action) {
@@ -130,7 +141,9 @@ public class KeybindsScreen extends VerticalLayoutScreen {
 
     if(action == INPUT_ACTION_MENU_BACK.get()) {
       playMenuSound(3);
-      InputBindings.saveBindings(this.config);
+      if(!Arrays.equals(this.openingBindings, snapshotBindings())) {
+        InputBindings.saveBindings(this.config);
+      }
       if(this.originalBindings != null) {
         InputBindings.initBindings();
         InputBindings.loadBindings(this.originalBindings);

--- a/src/main/java/legend/game/inventory/screens/KeybindsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/KeybindsScreen.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static legend.core.GameEngine.CONFIG;
 import static legend.core.GameEngine.PLATFORM;
 import static legend.core.GameEngine.REGISTRIES;
 import static legend.game.FullScreenEffects.startFadeEffect;
@@ -35,6 +36,7 @@ import static legend.game.sound.Audio.playMenuSound;
 public class KeybindsScreen extends VerticalLayoutScreen {
   private final Runnable unload;
   private final ConfigCollection config;
+  private final ConfigCollection originalBindings;
 
   public KeybindsScreen(final ConfigCollection config, final Runnable unload) {
     deallocateRenderables(0xff);
@@ -42,6 +44,11 @@ public class KeybindsScreen extends VerticalLayoutScreen {
 
     this.config = config;
     this.unload = unload;
+
+    this.originalBindings = config != CONFIG ? new ConfigCollection(false) : null;
+    if(this.originalBindings != null) {
+      InputBindings.saveBindings(this.originalBindings);
+    }
 
     InputBindings.initBindings();
     InputBindings.loadBindings(config);
@@ -124,6 +131,10 @@ public class KeybindsScreen extends VerticalLayoutScreen {
     if(action == INPUT_ACTION_MENU_BACK.get()) {
       playMenuSound(3);
       InputBindings.saveBindings(this.config);
+      if(this.originalBindings != null) {
+        InputBindings.initBindings();
+        InputBindings.loadBindings(this.originalBindings);
+      }
       this.unload.run();
       return InputPropagation.HANDLED;
     }

--- a/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
+++ b/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
@@ -68,6 +68,7 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
   private final Textbox campaignName;
   private final Dropdown<RegistryDelegate<CampaignType>> campaignType;
   private final Dropdown<ConfigPresetEntry> optionPresets;
+  private String appliedPreset;
 
   private boolean unload;
 
@@ -109,11 +110,13 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     ConfigPresetManager.loadDefaultPresets().forEach(this.optionPresets::addOption);
     ConfigPresetManager.loadPresetList().forEach(this.optionPresets::addOption);
     this.optionPresets.onSelection(this::onPresetSelected);
+    this.appliedPreset = IoHelper.slugName(this.optionPresets.getSelectedOption().getName().get());
 
     for(int i = 0; i < this.optionPresets.size(); i++) {
       if(IoHelper.slugName(this.optionPresets.getOption(i).getName().get()).equals(Config.getLastConfigPreset())) {
         this.optionPresets.setSelectedIndex(i);
         this.updateConfig(this.optionPresets.getSelectedOption().getPreset().config);
+        this.appliedPreset = Config.getLastConfigPreset();
         break;
       }
     }
@@ -176,13 +179,27 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
   }
 
   private void onPresetSelected(final int index) {
-    this.deferAction(() -> this.getStack().pushScreen(new MessageBoxScreen(I18n.translate("lod_core.ui.new_campaign.load_preset_confirm", this.optionPresets.getSelectedOption().getName()), MessageBoxType.CONFIRMATION, result -> {
+    final ConfigPresetEntry preset = this.optionPresets.getOption(index);
+    this.deferAction(() -> this.getStack().pushScreen(new MessageBoxScreen(I18n.translate("lod_core.ui.new_campaign.load_preset_confirm", preset.getName()), MessageBoxType.CONFIRMATION, result -> {
       if(result == MessageBoxResult.YES) {
-        this.updateConfig(this.optionPresets.getSelectedOption().getPreset().config);
+        this.updateConfig(preset.getPreset().config);
+        this.appliedPreset = IoHelper.slugName(preset.getName().get());
+        Config.setLastConfigPreset(this.appliedPreset);
+      } else {
+        this.restorePresetSelection();
       }
     })));
+  }
 
-    Config.setLastConfigPreset(IoHelper.slugName(this.optionPresets.getSelectedOption().getName().get()));
+  private void restorePresetSelection() {
+    this.optionPresets.setSelectedIndex(-1);
+
+    for(int i = 0; i < this.optionPresets.size(); i++) {
+      if(IoHelper.slugName(this.optionPresets.getOption(i).getName().get()).equals(this.appliedPreset)) {
+        this.optionPresets.setSelectedIndex(i);
+        return;
+      }
+    }
   }
 
   private void updateConfig(final ConfigCollection newConfig) {

--- a/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
+++ b/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
@@ -6,6 +6,7 @@ import legend.core.IoHelper;
 import legend.core.lang.I18nText;
 import legend.core.lang.RawText;
 import legend.core.platform.input.InputAction;
+import legend.core.platform.input.InputBindings;
 import legend.game.SItem;
 import legend.game.Scus94491BpeSegment_800b;
 import legend.game.i18n.I18n;
@@ -74,6 +75,8 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     loadingNewGameState_800bdc34 = false;
 
     CONFIG.clearConfig(ConfigStorageLocation.CAMPAIGN);
+    InputBindings.initBindings();
+    InputBindings.loadBindings(CONFIG);
     this.enabledMods.addAll(MODS.getAllModIds());
 
     deallocateRenderables(0xff);
@@ -196,6 +199,8 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     }
 
     CONFIG.copyConfigFrom(newConfig);
+    InputBindings.initBindings();
+    InputBindings.loadBindings(CONFIG);
 
     for(final var entry : oldValues.entrySet()) {
       final RegistryId id = entry.getKey();

--- a/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
+++ b/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
@@ -22,6 +22,7 @@ import legend.game.saves.Campaign;
 import legend.game.saves.CampaignType;
 import legend.game.saves.ConfigCollection;
 import legend.game.saves.ConfigEntry;
+import legend.game.saves.ConfigPreset;
 import legend.game.saves.ConfigPresetEntry;
 import legend.game.saves.ConfigPresetManager;
 import legend.game.saves.ConfigStorage;
@@ -115,8 +116,9 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     for(int i = 0; i < this.optionPresets.size(); i++) {
       if(IoHelper.slugName(this.optionPresets.getOption(i).getName().get()).equals(Config.getLastConfigPreset())) {
         this.optionPresets.setSelectedIndex(i);
-        this.updateConfig(this.optionPresets.getSelectedOption().getPreset().config);
-        this.appliedPreset = Config.getLastConfigPreset();
+        if(this.applyPreset(this.optionPresets.getSelectedOption())) {
+          this.appliedPreset = Config.getLastConfigPreset();
+        }
         break;
       }
     }
@@ -181,14 +183,25 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
   private void onPresetSelected(final int index) {
     final ConfigPresetEntry preset = this.optionPresets.getOption(index);
     this.deferAction(() -> this.getStack().pushScreen(new MessageBoxScreen(I18n.translate("lod_core.ui.new_campaign.load_preset_confirm", preset.getName()), MessageBoxType.CONFIRMATION, result -> {
-      if(result == MessageBoxResult.YES) {
-        this.updateConfig(preset.getPreset().config);
+      if(result == MessageBoxResult.YES && this.applyPreset(preset)) {
         this.appliedPreset = IoHelper.slugName(preset.getName().get());
         Config.setLastConfigPreset(this.appliedPreset);
       } else {
         this.restorePresetSelection();
       }
     })));
+  }
+
+  private boolean applyPreset(final ConfigPresetEntry entry) {
+    final ConfigPreset preset = entry.getPreset();
+    if(preset == null) {
+      this.restorePresetSelection();
+      this.deferAction(() -> this.getStack().pushScreen(new MessageBoxScreen(I18n.translate("lod_core.ui.options_presets.invalid_preset"), MessageBoxType.ALERT, result -> { })));
+      return false;
+    }
+
+    this.updateConfig(preset.config);
+    return true;
   }
 
   private void restorePresetSelection() {

--- a/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
+++ b/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
@@ -186,8 +186,6 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
   }
 
   private void updateConfig(final ConfigCollection newConfig) {
-    CONFIG.clearConfig();
-
     final Map<RegistryId, Object> oldValues = new HashMap<>();
 
     for(final RegistryId id : REGISTRIES.config) {
@@ -198,6 +196,7 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
       }
     }
 
+    CONFIG.clearConfig();
     CONFIG.copyConfigFrom(newConfig);
     InputBindings.initBindings();
     InputBindings.loadBindings(CONFIG);

--- a/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
+++ b/src/main/java/legend/game/inventory/screens/NewCampaignScreen.java
@@ -106,7 +106,10 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     this.campaignType.onSelection(index -> Scus94491BpeSegment_800b.campaignType = this.campaignType.getSelectedOption());
     Scus94491BpeSegment_800b.campaignType = campaignTypes.getFirst();
 
-    this.optionPresets = new Dropdown<>((i, e) -> e.getName());
+    this.optionPresets = new Dropdown<>((i, e) ->
+      IoHelper.slugName(e.getName().get()).equals(this.appliedPreset)
+        ? CONFIG.getPresetDisplayName() : e.getName()
+    );
     this.addRow(new I18nText("lod_core.ui.new_campaign.options_presets"), this.optionPresets);
     ConfigPresetManager.loadDefaultPresets().forEach(this.optionPresets::addOption);
     ConfigPresetManager.loadPresetList().forEach(this.optionPresets::addOption);
@@ -131,6 +134,7 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
         startFadeEffect(2, 10);
         this.getStack().popScreen();
         bootMods(this.enabledMods);
+        CONFIG.refreshPreset();
 
         this.optionPresets.clearOptions();
         presets.forEach(this.optionPresets::addOption);
@@ -143,6 +147,7 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     this.addRow(RawText.BLANK, options);
     options.onPressed(() ->
       this.getStack().pushScreen(new OptionsCategoryScreen(CONFIG, EnumSet.allOf(ConfigStorageLocation.class), () -> {
+        CONFIG.refreshPreset();
         startFadeEffect(2, 10);
         this.getStack().popScreen();
 
@@ -157,6 +162,7 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
       this.deferAction(() ->
         this.getStack().pushScreen(new ModsScreen(this.enabledMods, () -> {
           bootMods(this.enabledMods);
+          CONFIG.refreshPreset();
 
           startFadeEffect(2, 10);
           this.getStack().popScreen();
@@ -201,6 +207,7 @@ public class NewCampaignScreen extends VerticalLayoutScreen {
     }
 
     this.updateConfig(preset.config);
+    CONFIG.setPreset(preset.name);
     return true;
   }
 

--- a/src/main/java/legend/game/inventory/screens/OptionsPresetsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/OptionsPresetsScreen.java
@@ -11,7 +11,6 @@ import legend.game.saves.ConfigCollection;
 import legend.game.saves.ConfigPreset;
 import legend.game.saves.ConfigPresetEntry;
 import legend.game.saves.ConfigPresetManager;
-import legend.game.saves.ConfigStorage;
 import legend.game.saves.ConfigStorageLocation;
 import legend.game.types.MessageBoxResult;
 import legend.game.types.MessageBoxType;
@@ -80,7 +79,7 @@ public class OptionsPresetsScreen extends VerticalLayoutScreen {
       return;
     }
 
-    final ConfigCollection newConfig = new ConfigCollection();
+    final ConfigCollection newConfig = new ConfigCollection(false);
     newConfig.copyConfigFrom(preset.config);
     this.deferAction(() -> this.getStack().pushScreen(new OptionsCategoryScreen(newConfig, EnumSet.allOf(ConfigStorageLocation.class), () -> this.onOptionsClosed(preset.name.get(), newConfig, preset.config))));
   }
@@ -110,7 +109,7 @@ public class OptionsPresetsScreen extends VerticalLayoutScreen {
         return;
       }
 
-      final ConfigCollection newConfig = new ConfigCollection();
+      final ConfigCollection newConfig = new ConfigCollection(false);
 
       // Copy the reference config into the new one
       if(oldConfig != null) {
@@ -131,7 +130,6 @@ public class OptionsPresetsScreen extends VerticalLayoutScreen {
   private void onSaveChangesResult(final MessageBoxResult result, final String name, final ConfigCollection config, @Nullable final ConfigCollection originalConfig) {
     if(result == MessageBoxResult.YES) {
       final Path path = ConfigPresetManager.savePreset(name, config);
-      ConfigStorage.saveConfig(config, ConfigStorageLocation.GLOBAL, Path.of("config.dcnf"));
 
       if(originalConfig == null) {
         // We aren't editing an existing preset, add a new one to the list

--- a/src/main/java/legend/game/inventory/screens/OptionsPresetsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/OptionsPresetsScreen.java
@@ -81,6 +81,7 @@ public class OptionsPresetsScreen extends VerticalLayoutScreen {
 
     final ConfigCollection newConfig = new ConfigCollection(false);
     newConfig.copyConfigFrom(preset.config);
+    newConfig.setPreset(preset.name);
     this.deferAction(() -> this.getStack().pushScreen(new OptionsCategoryScreen(newConfig, EnumSet.allOf(ConfigStorageLocation.class), () -> this.onOptionsClosed(preset.name.get(), newConfig, preset.config))));
   }
 
@@ -114,6 +115,8 @@ public class OptionsPresetsScreen extends VerticalLayoutScreen {
       if(oldConfig != null) {
         newConfig.copyConfigFrom(oldConfig);
       }
+
+      newConfig.setPreset(new RawText(name));
 
       // Open the regular config editor
       this.deferAction(() -> this.getStack().pushScreen(new OptionsCategoryScreen(newConfig, EnumSet.allOf(ConfigStorageLocation.class), () -> this.onOptionsClosed(name, newConfig, null))));

--- a/src/main/java/legend/game/inventory/screens/OptionsPresetsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/OptionsPresetsScreen.java
@@ -89,8 +89,7 @@ public class OptionsPresetsScreen extends VerticalLayoutScreen {
   }
 
   private void onDeleteResult(final MessageBoxResult result) {
-    if(result == MessageBoxResult.YES) {
-      ConfigPresetManager.deletePreset(this.presetList.getSelectedOption());
+    if(result == MessageBoxResult.YES && ConfigPresetManager.deletePreset(this.presetList.getSelectedOption())) {
       this.presetList.removeOption(this.presetList.getSelectedIndex());
       this.onPresetSelected(this.presetList.getSelectedIndex());
     }
@@ -130,6 +129,7 @@ public class OptionsPresetsScreen extends VerticalLayoutScreen {
   private void onSaveChangesResult(final MessageBoxResult result, final String name, final ConfigCollection config, @Nullable final ConfigCollection originalConfig) {
     if(result == MessageBoxResult.YES) {
       final Path path = ConfigPresetManager.savePreset(name, config);
+      if(path == null) return;
 
       if(originalConfig == null) {
         // We aren't editing an existing preset, add a new one to the list

--- a/src/main/java/legend/game/inventory/screens/OptionsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/OptionsScreen.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static legend.core.GameEngine.CONFIG;
 import static legend.game.sound.Audio.playMenuSound;
 import static legend.game.FullScreenEffects.startFadeEffect;
 import static legend.game.Menus.deallocateRenderables;
@@ -38,6 +37,7 @@ import static legend.game.modding.coremod.CoreMod.SHOW_ADVANCED_OPTIONS_CONFIG;
 public class OptionsScreen extends VerticalLayoutScreen {
   private static final Logger LOGGER = LogManager.getFormatterLogger(OptionsScreen.class);
   private final Runnable unload;
+  private final ConfigCollection config;
 
   private final List<ConfigEntry<?>> configs = new ArrayList<>();
   private final Map<Control, Label> helpLabels = new HashMap<>();
@@ -47,6 +47,7 @@ public class OptionsScreen extends VerticalLayoutScreen {
     deallocateRenderables(0xff);
 
     this.unload = unload;
+    this.config = config;
     this.init();
 
     final Map<ConfigEntry<?>, TextComponent> translations = new HashMap<>();
@@ -113,7 +114,7 @@ public class OptionsScreen extends VerticalLayoutScreen {
         }
       });
 
-    this.addToggleHotkey(new I18nText("lod_core.ui.options.advanced"), INPUT_ACTION_MENU_ADVANCED, CONFIG.getConfig(SHOW_ADVANCED_OPTIONS_CONFIG.get()), this::advanced);
+    this.addToggleHotkey(new I18nText("lod_core.ui.options.advanced"), INPUT_ACTION_MENU_ADVANCED, this.config.getConfig(SHOW_ADVANCED_OPTIONS_CONFIG.get()), this::advanced);
     this.addHotkey(new I18nText("lod_core.ui.options.help"), INPUT_ACTION_MENU_HELP, this::help);
     this.addHotkey(new I18nText("lod_core.ui.options.back"), INPUT_ACTION_MENU_BACK, this::back);
   }
@@ -156,7 +157,7 @@ public class OptionsScreen extends VerticalLayoutScreen {
   }
 
   private void advanced(final boolean advanced) {
-    CONFIG.setConfig(SHOW_ADVANCED_OPTIONS_CONFIG.get(), advanced);
+    this.config.setConfig(SHOW_ADVANCED_OPTIONS_CONFIG.get(), advanced);
 
     for(int i = 0; i < this.configs.size(); i++) {
       this.setRowVisible(i, !this.configs.get(i).isAdvanced() || advanced);

--- a/src/main/java/legend/game/modding/coremod/config/AudioDeviceConfig.java
+++ b/src/main/java/legend/game/modding/coremod/config/AudioDeviceConfig.java
@@ -10,7 +10,6 @@ import legend.game.saves.ConfigEntry;
 import legend.game.saves.ConfigStorageLocation;
 
 import static legend.core.GameEngine.AUDIO_THREAD;
-import static legend.core.GameEngine.CONFIG;
 
 public class AudioDeviceConfig extends ConfigEntry<String> {
   public AudioDeviceConfig() {
@@ -18,13 +17,13 @@ public class AudioDeviceConfig extends ConfigEntry<String> {
 
     this.setEditControl((current, gameState) -> {
       final Dropdown<String> dropdown = new Dropdown<>((i, s) -> new RawText(s.replace("OpenAL Soft on ", "")));
-      dropdown.onSelection(index -> gameState.setConfig(this, dropdown.getSelectedOption()));
+      dropdown.onSelection(index -> gameState.setConfig(this, index == 0 ? "" : dropdown.getSelectedOption()));
       dropdown.addOption("<default>");
 
       for(final String device : AudioThread.getDevices()) {
         dropdown.addOption(device);
 
-        if(device.equals(CONFIG.getConfig(this))) {
+        if(device.equals(current)) {
           dropdown.setSelectedIndex(dropdown.size() - 1);
         }
       }

--- a/src/main/java/legend/game/modding/coremod/config/ControllerKeybindsConfigEntry.java
+++ b/src/main/java/legend/game/modding/coremod/config/ControllerKeybindsConfigEntry.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import org.legendofdragoon.modloader.registries.RegistryDelegate;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,7 @@ public class ControllerKeybindsConfigEntry extends ConfigEntry<Map<RegistryDeleg
 
     out.writeShort(offset, actionMap.size());
 
-    for(final var e : actionMap.entrySet()) {
+    for(final var e : actionMap.entrySet().stream().sorted(Comparator.comparing(entry -> entry.getKey().getId().toString())).toList()) {
       out.writeRegistryId(offset, e.getKey().getId());
       out.writeByte(offset, e.getValue().size());
 

--- a/src/main/java/legend/game/modding/coremod/config/MonitorConfigEntry.java
+++ b/src/main/java/legend/game/modding/coremod/config/MonitorConfigEntry.java
@@ -8,7 +8,6 @@ import legend.game.saves.ConfigCollection;
 import legend.game.saves.ConfigEntry;
 import legend.game.saves.ConfigStorageLocation;
 
-import static legend.core.GameEngine.CONFIG;
 import static legend.core.GameEngine.PLATFORM;
 import static legend.core.GameEngine.RENDERER;
 
@@ -32,7 +31,7 @@ public class MonitorConfigEntry extends ConfigEntry<Integer> {
         dropdown.addOption(new RawText(displays[i]));
       }
 
-      final int selected = CONFIG.getConfig(this);
+      final int selected = current;
       if(selected >= 0 && selected < displays.length) {
         dropdown.setSelectedIndex(selected);
       } else {

--- a/src/main/java/legend/game/saves/ConfigCollection.java
+++ b/src/main/java/legend/game/saves/ConfigCollection.java
@@ -16,8 +16,18 @@ import static legend.core.GameEngine.MODS;
 import static legend.core.GameEngine.REGISTRIES;
 
 public class ConfigCollection {
+  private final boolean notifyChanges;
   private final Map<RegistryId, Object> configValues = new HashMap<>();
   private final Map<RegistryId, Set<String>> locked = new HashMap<>();
+
+  public ConfigCollection() {
+    this(true);
+  }
+
+  /** Use false for detached edits that must not change runtime state or post events. */
+  public ConfigCollection(final boolean notifyChanges) {
+    this.notifyChanges = notifyChanges;
+  }
 
   public <T> T getConfig(final ConfigEntry<T> config) {
     //noinspection unchecked
@@ -27,8 +37,10 @@ public class ConfigCollection {
   public <T> void setConfig(final ConfigEntry<T> config, final T value) {
     final T oldValue = this.getConfig(config);
     this.setConfigQuietly(config, value);
-    config.onChange(this, oldValue, value);
-    EVENTS.postEvent(new ConfigUpdatedEvent(config));
+    if(this.notifyChanges) {
+      config.onChange(this, oldValue, value);
+      EVENTS.postEvent(new ConfigUpdatedEvent(config));
+    }
   }
 
   /** Doesn't trigger onChange */

--- a/src/main/java/legend/game/saves/ConfigCollection.java
+++ b/src/main/java/legend/game/saves/ConfigCollection.java
@@ -1,11 +1,14 @@
 package legend.game.saves;
 
+import legend.core.lang.I18nText;
+import legend.core.lang.TextComponent;
 import legend.game.modding.events.config.ConfigUpdatedEvent;
 import legend.lodmod.LodMod;
 import org.legendofdragoon.modloader.ModContainer;
 import org.legendofdragoon.modloader.registries.RegistryDelegate;
 import org.legendofdragoon.modloader.registries.RegistryId;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -19,6 +22,9 @@ public class ConfigCollection {
   private final boolean notifyChanges;
   private final Map<RegistryId, Object> configValues = new HashMap<>();
   private final Map<RegistryId, Set<String>> locked = new HashMap<>();
+  @Nullable
+  private ConfigPresetState presetState;
+  private long revision;
 
   public ConfigCollection() {
     this(true);
@@ -46,6 +52,32 @@ public class ConfigCollection {
   /** Doesn't trigger onChange */
   <T> void setConfigQuietly(final ConfigEntry<T> config, final T value) {
     this.configValues.put(config.getRegistryId(), value);
+    this.revision++;
+  }
+
+  /** Records the successfully applied preset without changing values or firing callbacks. */
+  public void setPreset(final TextComponent name) {
+    this.presetState = new ConfigPresetState(name, this, this.revision);
+  }
+
+  @Nullable
+  public TextComponent getPresetName() {
+    return this.presetState != null ? this.presetState.name : null;
+  }
+
+  public boolean isPresetModified() {
+    return this.presetState != null && this.presetState.isModified(this, this.revision);
+  }
+
+  public TextComponent getPresetDisplayName() {
+    if(this.presetState == null) return new I18nText("lod_core.config_presets.custom");
+    if(this.isPresetModified()) return new I18nText("lod_core.config_presets.modified", this.presetState.name);
+    return this.presetState.name;
+  }
+
+  /** Rechecks mutable values and registry defaults after returning from an editor or mod reload. */
+  public void refreshPreset() {
+    this.revision++;
   }
 
   public boolean hasConfig(final ConfigEntry<?> config) {
@@ -54,9 +86,11 @@ public class ConfigCollection {
 
   public void clearConfig() {
     this.configValues.clear();
+    this.presetState = null;
   }
 
   public void clearConfig(final ConfigStorageLocation storageLocation) {
+    this.presetState = null;
     this.configValues.keySet().removeIf(id -> {
       final RegistryDelegate<ConfigEntry<?>> delegate = REGISTRIES.config.getEntry(id);
       return !delegate.isValid() || delegate.get().storageLocation == storageLocation;
@@ -65,6 +99,7 @@ public class ConfigCollection {
 
   public void copyConfigFrom(final ConfigCollection other) {
     this.configValues.putAll(other.configValues);
+    this.presetState = null;
   }
 
   public void lockConfig(final ConfigEntry<?> config) {

--- a/src/main/java/legend/game/saves/ConfigEntry.java
+++ b/src/main/java/legend/game/saves/ConfigEntry.java
@@ -3,6 +3,9 @@ package legend.game.saves;
 import legend.game.inventory.screens.Control;
 import org.legendofdragoon.modloader.registries.RegistryEntry;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -25,6 +28,41 @@ public class ConfigEntry<T> extends RegistryEntry {
 
   public T getDefaultValue() {
     return this.defaultValue;
+  }
+
+  /**
+   * Stable preset value category, independent of Java implementation class names.
+   * Override for custom values or more specific collection/enum contracts.
+   * This describes compatibility; it does not validate the serialized bytes.
+   */
+  public String getPresetValueType() {
+    return switch(this.defaultValue) {
+      case Boolean ignored -> "boolean";
+      case Byte ignored -> "int8";
+      case Short ignored -> "int16";
+      case Integer ignored -> "int32";
+      case Long ignored -> "int64";
+      case Float ignored -> "float32";
+      case Double ignored -> "float64";
+      case Character ignored -> "char";
+      case String ignored -> "string";
+      case Enum<?> ignored -> "enum";
+      case byte[] ignored -> "bytes";
+      case String[] ignored -> "string_array";
+      case List<?> ignored -> "list";
+      case Set<?> ignored -> "set";
+      case Map<?, ?> ignored -> "map";
+      case null, default -> "opaque";
+    };
+  }
+
+  /**
+   * Positive version of this entry's preset encoding. Override and increment when
+   * changing its binary layout or meaning, including collection elements or enum domains.
+   * Readers require an exact match. Legacy presets without metadata cannot be checked.
+   */
+  public int getPresetSchemaVersion() {
+    return 1;
   }
 
   protected void setEditControl(final BiFunction<T, ConfigCollection, Control> editControl) {

--- a/src/main/java/legend/game/saves/ConfigPresetEntry.java
+++ b/src/main/java/legend/game/saves/ConfigPresetEntry.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.nio.file.Path;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -26,10 +27,9 @@ public class ConfigPresetEntry {
   }
 
   public TextComponent getName() {
-    if(this.resolver.isDone()) {
-      try {
-        return this.resolver.get().name;
-      } catch(final InterruptedException | ExecutionException ignored) { }
+    if(this.resolver.isDone() && !this.resolver.isCompletedExceptionally()) {
+      final ConfigPreset preset = this.resolver.getNow(null);
+      if(preset != null) return preset.name;
     }
 
     return this.temporaryName;
@@ -38,9 +38,13 @@ public class ConfigPresetEntry {
   public @Nullable ConfigPreset getPreset() {
     try {
       return this.resolver.get();
-    } catch(final InterruptedException | ExecutionException e) {
-      LOGGER.warn("Failed to load preset " + this.getName(), e);
-      return null;
+    } catch(final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn("Interrupted while loading preset " + this.temporaryName, e);
+    } catch(final ExecutionException | CancellationException e) {
+      LOGGER.warn("Failed to load preset " + this.temporaryName, e);
     }
+
+    return null;
   }
 }

--- a/src/main/java/legend/game/saves/ConfigPresetManager.java
+++ b/src/main/java/legend/game/saves/ConfigPresetManager.java
@@ -18,12 +18,14 @@ import legend.game.unpacker.FileData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -77,12 +79,16 @@ public final class ConfigPresetManager {
     }
   }
 
-  public static void deletePreset(final ConfigPresetEntry presetEntry) {
+  public static boolean deletePreset(final ConfigPresetEntry presetEntry) {
+    if(!presetEntry.editable || presetEntry.path == null) return false;
+
     try {
       Files.deleteIfExists(presetEntry.path);
-    } catch(final IOException e) {
+      return true;
+    } catch(final IOException | SecurityException e) {
       GameOverlay.addNotification(5, new I18nText("lod_core.ui.options_presets.delete_failed"));
       LOGGER.warn("Failed to delete preset", e);
+      return false;
     }
   }
 
@@ -132,32 +138,45 @@ public final class ConfigPresetManager {
     }
   }
 
-  public static Path savePreset(final String name, final ConfigCollection config) {
-    final MapTag tag = new MapTag();
-
-    tag.set("name", new StringTag(name));
-
-    for(final ConfigStorageLocation location : ConfigStorageLocation.values()) {
-      ConfigStorage.saveConfig(config, location, tag);
-    }
-
-    final FileData data = new ExpandableFileData(256);
-    final IntRef offset = new IntRef();
-    tag.serialize(data, offset);
-
-    final byte[] out = new byte[offset.get()];
-    data.read(0, out, 0, offset.get());
-
-    final Path path = configPath.resolve(IoHelper.slugName(name) + ".dpre");
-
+  public static @Nullable Path savePreset(final String name, final ConfigCollection config) {
     try {
-      Files.write(path, out, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-    } catch(final IOException e) {
-      GameOverlay.addNotification(5, new I18nText("lod_core.ui.options_presets.failed_to_save_preset"));
-      LOGGER.warn("Failed to save options preset", e);
-    }
+      final MapTag tag = new MapTag();
+      tag.set("name", new StringTag(name));
 
-    return path;
+      for(final ConfigStorageLocation location : ConfigStorageLocation.values()) {
+        ConfigStorage.saveConfig(config, location, tag);
+      }
+
+      final FileData data = new ExpandableFileData(256);
+      final IntRef offset = new IntRef();
+      tag.serialize(data, offset);
+
+      final byte[] out = new byte[offset.get()];
+      data.read(0, out, 0, offset.get());
+
+      final Path path = configPath.resolve(IoHelper.slugName(name) + ".dpre");
+      writePreset(path, out);
+      return path;
+    } catch(final IOException | RuntimeException e) {
+      GameOverlay.addNotification(5, new I18nText("lod_core.ui.options_presets.failed_to_save_preset"));
+      LOGGER.warn("Failed to save options preset %s", name, e);
+      return null;
+    }
+  }
+
+  private static void writePreset(final Path path, final byte[] data) throws IOException {
+    Files.createDirectories(path.toAbsolutePath().getParent());
+    final Path temporaryFile = Files.createTempFile(path.toAbsolutePath().getParent(), "preset-", ".tmp");
+    try {
+      Files.write(temporaryFile, data);
+      try {
+        Files.move(temporaryFile, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch(final AtomicMoveNotSupportedException e) {
+        Files.move(temporaryFile, path, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temporaryFile);
+    }
   }
 
   public static List<ConfigPresetEntry> loadDefaultPresets() {

--- a/src/main/java/legend/game/saves/ConfigPresetManager.java
+++ b/src/main/java/legend/game/saves/ConfigPresetManager.java
@@ -4,6 +4,7 @@ import legend.core.IoHelper;
 import legend.core.lang.I18nText;
 import legend.core.lang.RawText;
 import legend.core.memory.types.IntRef;
+import legend.core.tags.IntTag;
 import legend.core.tags.MapTag;
 import legend.core.tags.StringTag;
 import legend.game.combat.BattleTransitionMode;
@@ -54,6 +55,7 @@ public final class ConfigPresetManager {
   private ConfigPresetManager() { }
 
   private static final Logger LOGGER = LogManager.getFormatterLogger(ConfigPresetManager.class);
+  private static final int FORMAT_VERSION = 1;
 
   private static final Path configPath = Path.of("config");
   public static final PathMatcher CONFIG_MATCHER = FileSystems.getDefault().getPathMatcher("glob:*.dpre");
@@ -122,6 +124,7 @@ public final class ConfigPresetManager {
       final IntRef offset = new IntRef();
       final MapTag tag = new MapTag();
       tag.deserialize(data, offset);
+      validatePresetFormat(tag);
 
       final String name = tag.get("name").asString().get();
 
@@ -142,6 +145,7 @@ public final class ConfigPresetManager {
     try {
       final MapTag tag = new MapTag();
       tag.set("name", new StringTag(name));
+      tag.set("formatVersion", new IntTag(FORMAT_VERSION));
 
       for(final ConfigStorageLocation location : ConfigStorageLocation.values()) {
         ConfigStorage.saveConfig(config, location, tag);
@@ -161,6 +165,13 @@ public final class ConfigPresetManager {
       GameOverlay.addNotification(5, new I18nText("lod_core.ui.options_presets.failed_to_save_preset"));
       LOGGER.warn("Failed to save options preset %s", name, e);
       return null;
+    }
+  }
+
+  private static void validatePresetFormat(final MapTag tag) {
+    // Existing presets have no version tag and remain readable as legacy data.
+    if(tag.has("formatVersion") && tag.get("formatVersion").asInt().get() != FORMAT_VERSION) {
+      throw new IllegalArgumentException("Unsupported preset format version");
     }
   }
 

--- a/src/main/java/legend/game/saves/ConfigPresetManager.java
+++ b/src/main/java/legend/game/saves/ConfigPresetManager.java
@@ -125,9 +125,9 @@ public final class ConfigPresetManager {
       }
 
       return new ConfigPreset(new RawText(name), config);
-    } catch(final IOException e) {
+    } catch(final IOException | RuntimeException e) {
       GameOverlay.addNotification(5, new I18nText("lod_core.ui.options_presets.failed_to_load_preset"));
-      LOGGER.warn("Failed to load options preset", e);
+      LOGGER.warn("Failed to load options preset %s", path, e);
       return null;
     }
   }

--- a/src/main/java/legend/game/saves/ConfigPresetState.java
+++ b/src/main/java/legend/game/saves/ConfigPresetState.java
@@ -1,0 +1,70 @@
+package legend.game.saves;
+
+import legend.core.lang.TextComponent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.legendofdragoon.modloader.registries.RegistryId;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static legend.core.GameEngine.REGISTRIES;
+
+/** Transient preset identity and immutable value baseline; never written to config files. */
+final class ConfigPresetState {
+  private static final Logger LOGGER = LogManager.getFormatterLogger(ConfigPresetState.class);
+
+  final TextComponent name;
+  private final Map<RegistryId, byte[]> values = new HashMap<>();
+  private long checkedRevision;
+  private boolean modified;
+
+  ConfigPresetState(final TextComponent name, final ConfigCollection config, final long revision) {
+    this.name = name;
+    this.checkedRevision = revision;
+
+    for(final RegistryId id : REGISTRIES.config) {
+      final ConfigEntry<?> entry = REGISTRIES.config.getEntry(id).get();
+
+      try {
+        this.values.put(id, serialize(config, entry).clone());
+      } catch(final RuntimeException exception) {
+        // An unreadable setting cannot establish an exact preset match.
+        this.values.put(id, null);
+        this.modified = true;
+        LOGGER.warn("Unable to track preset setting %s", id, exception);
+      }
+    }
+  }
+
+  boolean isModified(final ConfigCollection config, final long revision) {
+    if(this.checkedRevision != revision) {
+      this.modified = !this.matches(config);
+      this.checkedRevision = revision;
+    }
+
+    return this.modified;
+  }
+
+  private boolean matches(final ConfigCollection config) {
+    if(this.values.size() != REGISTRIES.config.size()) return false;
+
+    for(final RegistryId id : REGISTRIES.config) {
+      final byte[] original = this.values.get(id);
+      if(original == null) return false;
+
+      try {
+        if(!Arrays.equals(original, serialize(config, REGISTRIES.config.getEntry(id).get()))) return false;
+      } catch(final RuntimeException exception) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static <T> byte[] serialize(final ConfigCollection config, final ConfigEntry<T> entry) {
+    return entry.serializer.apply(config.getConfig(entry));
+  }
+}

--- a/src/main/java/legend/game/saves/ConfigStorage.java
+++ b/src/main/java/legend/game/saves/ConfigStorage.java
@@ -2,10 +2,12 @@ package legend.game.saves;
 
 import legend.core.lang.I18nText;
 import legend.core.memory.types.IntRef;
+import legend.core.tags.IntTag;
 import legend.core.tags.ListTag;
 import legend.core.tags.MapTag;
 import legend.core.tags.RawTag;
 import legend.core.tags.RegistryIdTag;
+import legend.core.tags.StringTag;
 import legend.game.modding.coremod.CoreMod;
 import legend.game.modding.events.config.ConfigLoadedEvent;
 import legend.game.ui.GameOverlay;
@@ -169,7 +171,7 @@ public final class ConfigStorage {
           throw new IllegalArgumentException("Incorrect storage location for " + configId);
         }
 
-        loadConfigValue(configs, configEntry, configTag);
+        loadConfigValue(configs, configEntry, configTag, tag.has("formatVersion"));
       } catch(final RuntimeException e) {
         skipped++;
         LOGGER.warn("Skipping preset setting %s at %s[%d]", configId, storageLocation, configIndex, e);
@@ -184,7 +186,15 @@ public final class ConfigStorage {
     RENDERER.setFrameSkipOption(CONFIG.getConfig(CoreMod.FRAME_SKIP_CONFIG.get()));
   }
 
-  private static <T> void loadConfigValue(final ConfigCollection configs, final ConfigEntry<T> configEntry, final MapTag configTag) {
+  private static <T> void loadConfigValue(final ConfigCollection configs, final ConfigEntry<T> configEntry, final MapTag configTag, final boolean requireSchema) {
+    if(requireSchema || configTag.has("valueType") || configTag.has("schemaVersion")) {
+      final String valueType = configTag.get("valueType").asString().get();
+      final int schemaVersion = configTag.get("schemaVersion").asInt().get();
+      if(!configEntry.getPresetValueType().equals(valueType) || schemaVersion <= 0 || schemaVersion != configEntry.getPresetSchemaVersion()) {
+        throw new IllegalArgumentException("Incompatible preset type/schema " + valueType + '/' + schemaVersion + " for " + configEntry.getRegistryId());
+      }
+    }
+
     final byte[] data = configTag.get("data").asRaw().get();
     final T value = Objects.requireNonNull(configEntry.deserializer.apply(data), "Config deserializer returned null");
     configs.setConfigQuietly(configEntry, value);
@@ -207,6 +217,7 @@ public final class ConfigStorage {
           locationTag.add(configTag);
 
           configTag.set("configId", new RegistryIdTag(configId));
+          saveConfigSchema(configEntry, configTag);
           //noinspection unchecked
           configTag.set("data", new RawTag((byte[])configEntry.serializer.apply(value)));
         } else {
@@ -214,5 +225,16 @@ public final class ConfigStorage {
         }
       }
     }
+  }
+
+  private static void saveConfigSchema(final ConfigEntry<?> configEntry, final MapTag configTag) {
+    final String valueType = configEntry.getPresetValueType();
+    final int schemaVersion = configEntry.getPresetSchemaVersion();
+    if(valueType == null || valueType.isBlank() || schemaVersion <= 0) {
+      throw new IllegalArgumentException("Invalid preset schema for " + configEntry.getRegistryId());
+    }
+
+    configTag.set("valueType", new StringTag(valueType));
+    configTag.set("schemaVersion", new IntTag(schemaVersion));
   }
 }

--- a/src/main/java/legend/game/saves/ConfigStorage.java
+++ b/src/main/java/legend/game/saves/ConfigStorage.java
@@ -1,5 +1,6 @@
 package legend.game.saves;
 
+import legend.core.lang.I18nText;
 import legend.core.memory.types.IntRef;
 import legend.core.tags.ListTag;
 import legend.core.tags.MapTag;
@@ -7,6 +8,7 @@ import legend.core.tags.RawTag;
 import legend.core.tags.RegistryIdTag;
 import legend.game.modding.coremod.CoreMod;
 import legend.game.modding.events.config.ConfigLoadedEvent;
+import legend.game.ui.GameOverlay;
 import legend.game.unpacker.FileData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -18,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static legend.core.GameEngine.CONFIG;
 import static legend.core.GameEngine.EVENTS;
@@ -148,33 +151,43 @@ public final class ConfigStorage {
     configs.clearConfig(storageLocation);
 
     final ListTag locationTag = tag.get(storageLocation.name()).asList();
+    int skipped = 0;
 
     for(int configIndex = 0; configIndex < locationTag.size(); configIndex++) {
-      final MapTag configTag = locationTag.get(configIndex).asMap();
-      final RegistryId configId = configTag.get("configId").asRegistryId().get();
+      RegistryId configId = null;
+      try {
+        final MapTag configTag = locationTag.get(configIndex).asMap();
+        configId = configTag.get("configId").asRegistryId().get();
+        final RegistryDelegate<ConfigEntry<?>> delegate = REGISTRIES.config.getEntry(configId);
 
-      final RegistryDelegate<ConfigEntry<?>> delegate = REGISTRIES.config.getEntry(configId);
-
-      if(delegate.isValid()) {
-        //noinspection rawtypes
-        final ConfigEntry configEntry = delegate.get();
-        final byte[] configValueRaw = configTag.get("data").asRaw().get();
-
-        if(configEntry != null) {
-          if(configEntry.storageLocation == storageLocation) {
-            //noinspection unchecked
-            configs.setConfigQuietly(configEntry, configEntry.deserializer.apply(configValueRaw));
-          }
-        } else {
-          LOGGER.warn("Unknown config ID %s", configId);
+        if(!delegate.isValid()) {
+          throw new IllegalArgumentException("Unknown config ID " + configId);
         }
-      } else {
-        LOGGER.warn("Unknown mod ID %s", configId);
+
+        final ConfigEntry<?> configEntry = delegate.get();
+        if(configEntry.storageLocation != storageLocation) {
+          throw new IllegalArgumentException("Incorrect storage location for " + configId);
+        }
+
+        loadConfigValue(configs, configEntry, configTag);
+      } catch(final RuntimeException e) {
+        skipped++;
+        LOGGER.warn("Skipping preset setting %s at %s[%d]", configId, storageLocation, configIndex, e);
       }
+    }
+
+    if(skipped != 0) {
+      GameOverlay.addNotification(5, new I18nText("lod_core.ui.options_presets.skipped_settings", skipped));
     }
 
     EVENTS.postEvent(new ConfigLoadedEvent(configs, storageLocation));
     RENDERER.setFrameSkipOption(CONFIG.getConfig(CoreMod.FRAME_SKIP_CONFIG.get()));
+  }
+
+  private static <T> void loadConfigValue(final ConfigCollection configs, final ConfigEntry<T> configEntry, final MapTag configTag) {
+    final byte[] data = configTag.get("data").asRaw().get();
+    final T value = Objects.requireNonNull(configEntry.deserializer.apply(data), "Config deserializer returned null");
+    configs.setConfigQuietly(configEntry, value);
   }
 
   public static void saveConfig(final ConfigCollection configs, final ConfigStorageLocation storageLocation, final MapTag tag) {

--- a/src/main/resources/lod_core/lang/en.lang
+++ b/src/main/resources/lod_core/lang/en.lang
@@ -18,6 +18,8 @@ lod_core.font.invalid.name=<INVALID>
 
 # Config presets
 lod_core.config_presets.severed_chains=Severed Chains
+lod_core.config_presets.modified=%s (Modified)
+lod_core.config_presets.custom=Custom configuration
 lod_core.config_presets.vanilla=Vanilla
 lod_core.config_presets.speedrunner=Speedrunner
 

--- a/src/main/resources/lod_core/lang/en.lang
+++ b/src/main/resources/lod_core/lang/en.lang
@@ -112,6 +112,7 @@ lod_core.ui.options_presets.failed_to_load_presets=Failed to load options preset
 lod_core.ui.options_presets.save_changes=Would you like to\nsave your changes?
 lod_core.ui.options_presets.invalid_preset=This preset is\ninvalid
 lod_core.ui.options_presets.back=Back
+lod_core.ui.options_presets.skipped_settings=Skipped %d invalid or unavailable preset settings; see log for details
 
 lod_core.ui.options.advanced=Advanced
 lod_core.ui.options.help=Help


### PR DESCRIPTION
### Motivation
- Some things from the defunc remember campaign PR that
  - Aren't fixed / covered by config-presets
  - Learnings
- Using the presets there seemed to be bugs with irongoon flows in testing the UI stuff out that were SC based

### Description

| Commit | Category / context | Example of the fixed user flow |
|---|---|---|
| `4faa3c2d6` | New campaign / input bindings | Select a preset with custom controls, confirm it, and immediately start a campaign; the game now uses those controls without requiring another menu visit |
| `8635abd51` | Preset application / settings callbacks | Switch from a named audio device to a preset using the default device; the change callback now receives the actual previous value and reinitializes audio |
| `961d07e64` | Preset editor / isolated changes | Edit a preset’s volume, font, or controls, then discard the changes; ordinary edits no longer affect active settings, and temporary keybinding changes are restored |
| `04bdc929c` | New campaign / selection confirmation | Select a different preset and answer No to confirmation; the dropdown returns to the previously applied preset, and the rejected choice is not remembered |
| `5b9b8a441` | Preset loading / error handling | Open New Campaign with an unreadable remembered preset or select a preset whose loading failed; the menu remains usable, reports the failure, and preserves active settings |
| `0c3ff485f` | Preset persistence / filesystem failures | Save an existing preset when replacement fails, or delete one when access is denied; the UI preserves its existing entry instead of reporting success |
| `87c331c15` | Input bindings / registry resolution | Apply saved controls after the input registry has been replaced; bindings now resolve action IDs through the current registry instead of relying on retained delegates |
| `addfe4047` | Preset loading / per-entry recovery | Load a preset containing one setting that fails to deserialize; valid settings still load, the rejected setting retains its default, and a notification reports skipped entries |
| `cf3e4e8ca` | Preset compatibility / type and schema | Load a preset whose setting metadata no longer matches the installed mod; that setting is skipped before decoding, while legacy presets without metadata remain readable |

### QA

| Commit | Steps on SC main | Expected baseline issue | Expected on sclocal |
|---|---|---|---|
| `4faa3c2d6` | 1. Save a preset with a noticeably different gameplay binding<br>2. Restart SC<br>3. Open New Campaign, select that preset, and confirm<br>4. Start without opening Controls, Mods, or Edit Presets<br>5. Try the changed binding | The previous/default mapping remains active | The preset’s mapping works immediately |
| `8635abd51` | 1. Configure a named audio output different from the OS default<br>2. Confirm audio uses that device<br>3. Open New Campaign and apply a built-in preset using the default audio device<br>4. Check the actual audio output | Configuration changes to default, but audio reinitialization is skipped | Audio reinitializes using the default device |
| `961d07e64` | 1. Open the title-screen preset editor<br>2. Create or select an editable preset<br>3. Change master volume while audio is playing<br>4. Leave and answer No to saving<br>5. Repeat with font selection<br>6. Separately edit keybindings and leave their editor | Discarded volume/font edits affect the running game; edited bindings can remain active | Draft volume/font edits do not affect runtime; leaving the keybinding editor restores active bindings |
| `04bdc929c` | 1. Create presets A and B with different settings<br>2. In New Campaign, apply A<br>3. Select B and answer No<br>4. Observe the dropdown<br>5. Leave New Campaign and reopen it | Dropdown displays B while A remains active; reopening can apply the rejected B | Dropdown returns to A, and reopening does not apply the rejected B |
| `5b9b8a441` | 1. Create and apply a disposable preset so it becomes remembered<br>2. Exit SC<br>3. Empty only that preset’s `.dpre` file<br>4. Restart SC and open New Campaign | Loading the remembered preset can crash the menu | An error appears, the menu remains usable, and the invalid preset is not applied |
| `0c3ff485f` | 1. Save a disposable preset and record one setting<br>2. Mark its `.dpre` file read-only in Windows<br>3. Edit that setting and confirm Save<br>4. Compare its value within the session and after restarting<br>5. Attempt to delete the read-only preset | Failed saves can update the in-memory preset; failed deletion removes its list entry | Failed saves preserve the original in-memory preset; failed deletion preserves its list entry |
| `87c331c15` | 1. Retain saved binding delegates from an input registry<br>2. Replace the registry instance with newly constructed actions under the same IDs<br>3. Load the retained bindings<br>4. Trigger the configured input | Bindings can target old action objects | Bindings resolve action IDs through the current registry |
| `addfe4047` | 1. Include a valid setting with a recognizable nondefault value<br>2. Include another setting whose payload makes its deserializer throw<br>3. Keep outer tags and storage sections valid<br>4. Load and apply the preset | One malformed setting aborts preset loading | Valid settings load, the bad setting retains its default, and a notification reports skipped settings |
| `cf3e4e8ca` | 1. Save a preset using sclocal<br>2. Make separate copies with a mismatched `valueType`, mismatched positive `schemaVersion`, and unsupported root `formatVersion`<br>3. Keep payloads valid<br>4. Load each copy in both builds<br>5. Also load an untouched preset saved by SC main | Main ignores the additional metadata and attempts to load the payloads | Type/schema mismatches skip affected settings; unsupported format rejects the preset; legacy presets still load |
