### PR TITLE
Feature: Utilize hasGood for axe from shack

### DIFF
--- a/patches/scripts.csv
+++ b/patches/scripts.csv
@@ -148,6 +148,8 @@ diff,SECT/DRGN21.BIN/120/4,scripts/DRGN21/120/4.diff,"Prairie prison escape cuts
 diff,SECT/DRGN21.BIN/123/1,scripts/DRGN21/123/1.diff,"Prairie prison escape cutscene #2, Dart, widescreen patch"
 diff,SECT/DRGN21.BIN/123/3,scripts/DRGN21/123/3.diff,"Prairie prison escape cutscene #2, Shana, widescreen patch"
 diff,SECT/DRGN21.BIN/123/4,scripts/DRGN21/123/4.diff,"Prairie prison escape cutscene #2, Lavitz, widescreen patch"
+diff,SECT/DRGN21.BIN/123/4,scripts/DRGN21/123/4.diff,"Prairie prison escape cutscene #2, Lavitz, widescreen patch"
+diff,SECT/DRGN21.BIN/132/1,scripts/DRGN21/132/1.diff,"Prairie tree check for axe from shack, GH#2809"
 diff,SECT/DRGN21.BIN/249/5,scripts/DRGN21/249/5.diff,"Lavitz's home, add animation to fix hug position, GH#1196"
 diff,SECT/DRGN21.BIN/270/1,scripts/DRGN21/270/1.diff,"Indels Castle, fix ladder animations"
 diff,SECT/DRGN21.BIN/276/1,scripts/DRGN21/276/1.diff,"Indels Castle, fix ladder animations"

--- a/patches/scripts/DRGN21/132/1.diff
+++ b/patches/scripts/DRGN21/132/1.diff
@@ -1,0 +1,11 @@
+--- original
++++ modified
+@@ -629,7 +629,7 @@
+ JMP_1140_0:
+ call 5, 0xd, stor[24]
+ jmp_cmp ==, 0x1, stor[24], inl[:LABEL_57]
+-call 3, 0x1, stor[24]
++call 914, id[lod:axe_from_shack], stor[24]
+ jmp_cmp !=, 0x0, stor[24], inl[:LABEL_56]
+ gosub inl[:LABEL_58]
+ LABEL_56:


### PR DESCRIPTION
Part of #2809 

I elected to check the good on the last bit of the tree's interaction. This way, players still need to trigger the proper story flags to enable the hasGood check.